### PR TITLE
fix(ci): install pytest in framework-auto-update workflow

### DIFF
--- a/.github/workflows/framework-auto-update.yml
+++ b/.github/workflows/framework-auto-update.yml
@@ -33,8 +33,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install package
-        run: pip install -e .
+      - name: Install package and test dependencies
+        # pytest needed for the framework_research --apply test gate.
+        # Matches the bridge-maintenance.yml install pattern.
+        run: pip install -e . pytest
 
       - name: Refresh framework-research snapshot
         run: python scripts/research_claude_code_docs.py


### PR DESCRIPTION
## Summary

The 2026-05-26 08:33Z scheduled fire of `framework-auto-update.yml`
failed with `No module named pytest`. The install step omitted pytest;
the `--apply` test gate immediately fails on the missing import, the
apply correctly reverts its edits, and the job exits 1.

One-line fix: `pip install -e .` → `pip install -e . pytest`,
matching the `bridge-maintenance.yml` pattern.

## Test plan

- [x] `tests/test_auto_update_workflow.py` still passes locally.
- [ ] CI green on this PR.
- [ ] Manual `workflow_dispatch` of framework-auto-update.yml after merge confirms green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)