### PR TITLE
1.0.0-rc.2 prep: dedup-hash fix, dry-run halt preview, labels, test extras

### DIFF
--- a/.github/workflows/bridge-maintenance.yml
+++ b/.github/workflows/bridge-maintenance.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install package and test dependencies
-        run: pip install -e . pytest
+        run: pip install -e ".[test]"
 
       - name: Run daily bridge maintenance (autonomous)
         run: bash scripts/run_daily_bridge_maintenance.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: python scripts/verify-env.py
 
       - name: Install package and pytest
-        run: pip install -e . pytest
+        run: pip install -e ".[test]"
 
       - name: Run tests
         run: pytest tests/

--- a/.github/workflows/framework-auto-update.yml
+++ b/.github/workflows/framework-auto-update.yml
@@ -130,4 +130,6 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "auto: framework upstream-token observation ($PHASH)" \
-            --body-file "$body_file"
+            --body-file "$body_file" \
+            --label "framework-update" \
+            --label "automerge:false"

--- a/.github/workflows/framework-auto-update.yml
+++ b/.github/workflows/framework-auto-update.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install package and test dependencies
         # pytest needed for the framework_research --apply test gate.
         # Matches the bridge-maintenance.yml install pattern.
-        run: pip install -e . pytest
+        run: pip install -e ".[test]"
 
       - name: Refresh framework-research snapshot
         run: python scripts/research_claude_code_docs.py

--- a/.github/workflows/framework-auto-update.yml
+++ b/.github/workflows/framework-auto-update.yml
@@ -54,8 +54,12 @@ jobs:
           if [[ "$changes" -eq 0 ]]; then
             echo "no_proposal=true" >> "$GITHUB_OUTPUT"
           else
-            # Stable per-content hash drives the branch name and dedup.
-            phash=$(python -c "import hashlib,json; d=json.load(open('$proposal')); s=json.dumps(d['changes'], sort_keys=True); print(hashlib.sha256(s.encode()).hexdigest()[:12])")
+            # Use the module's dedup_hash field (proposal schema 1.2+). It is
+            # computed over upstream tokens + adapter constants only — NOT
+            # over the rendered new_text (which contains today's date), so
+            # day-over-day runs with identical observations produce the same
+            # hash and the workflow's existing dedup step finds the open PR.
+            phash=$(python -c "import json; d=json.load(open('$proposal')); print(d.get('dedup_hash') or d.get('changes', [{}])[0].get('path','unknown'))")
             echo "phash=$phash" >> "$GITHUB_OUTPUT"
             echo "branch=auto/framework-update-$phash" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install package and test dependencies
-        run: pip install -e . pytest
+        run: pip install -e ".[test]"
 
       - name: Run daily agentteams security maintenance (autonomous)
         run: bash scripts/run_daily_security_maintenance.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(no changes since 1.0.0-rc.1)
+(no changes since 1.0.0-rc.2)
+
+## [1.0.0-rc.2] - 2026-05-27
+
+Second release candidate. Soak continues; no public-API breaks
+since rc.1. Bugfixes against the supervised auto-update loop, plus
+small quality-of-life features and a test-extras refactor.
+
+### fixed
+
+- **Auto-PR dedup hash no longer includes today's date.**
+  `framework_research.propose_module_patch` now emits a top-level
+  `dedup_hash` field (proposal schema bumped to 1.2) computed only
+  over upstream tokens and adapter constants. The
+  `framework-auto-update.yml` workflow's hash step reads this
+  field instead of hashing the rendered new_text. Effect: on
+  no-drift days, the proposal hash matches the prior day's PR,
+  the existing dedup check finds the open PR, and no duplicate
+  is created. Symptom that triggered the fix: rc.1 opened a fresh
+  PR each scheduled run even when observed tokens were
+  byte-identical.
+- **Blank-line accumulation in observation splices.**
+  `_splice_observation_block` now collapses any run of three or
+  more newlines to a single blank line after substitution.
+  Previously each daily refresh added one extra blank line above
+  the heading.
+
+### added
+
+- **`--shrink-policy=halt` pre-flight in dry-run.** `emit.emit_all`
+  with `dry_run=True, shrink_policy="halt"` populates
+  `EmitResult.shrink_blocked` with paths that a real run would
+  refuse, without modifying any file. Lets operators preview a
+  halt-mode posture before adopting it.
+- **Auto-PR labels.** The `framework-auto-update.yml` workflow now
+  applies `framework-update` and `automerge:false` labels at PR
+  creation. Improves the discovery surface and signals to future
+  reviewers that the PR must not be auto-merged. Labels created
+  on the remote with `gh label create`.
+- **Operational-JSON allow-list audit in the daily digest.**
+  `scripts/daily_pipeline_digest.py` walks the gitignored
+  `.github/agents/references/*.json` tree and flags any
+  non-allow-listed file whose lines exceed a 5% density of
+  absolute paths or high-entropy hex tokens. Catches future
+  generated files escaping `scan._OPERATIONAL_JSON_NAMES` before
+  they re-block the daily security scan.
+- **`[project.optional-dependencies] test` extras group.**
+  pyproject declares `test = ["pytest>=8", "pyyaml>=6"]`; CI
+  workflows now install via `pip install -e ".[test]"`. Runtime
+  dependency list unchanged (jsonschema only); the wheel stays
+  small.
+
+### infrastructure
+
+- **Initial scheduled auto-update fires hardened during soak.**
+  Three issues found and fixed on 2026-05-26:
+    - `pytest` was missing from `framework-auto-update.yml`'s
+      install step.
+    - `actions/permissions/workflow.can_approve_pull_request_reviews`
+      defaulted to `false`; enabled via `gh api`.
+    - A stale transient branch from the failed first dispatch was
+      cleaned up.
+  Result: subsequent auto-update PRs opened successfully under
+  the supervised pattern.
 
 ## [1.0.0-rc.1] - 2026-05-25
 

--- a/agentteams/emit.py
+++ b/agentteams/emit.py
@@ -831,6 +831,15 @@ def emit_all(
                     result.notices.append(f"{rel_path}: {notice}")
                     if result.dry_run_report is not None:
                         result.dry_run_report.notices.append(f"{rel_path}: {notice}")
+                # T5.1 / IV.1: in dry-run, also pre-flight the halt decision
+                # so operators see what a real --shrink-policy=halt run would
+                # block, without actually modifying any file.
+                if (
+                    mr.shrink_notices
+                    and shrink_policy == "halt"
+                    and result.dry_run_report is not None
+                ):
+                    result.shrink_blocked.append(str(target))
                 if mr.has_errors:
                     legacy_no_fence = all(
                         "No fence markers detected" in e for e in mr.parse_errors

--- a/agentteams/framework_research.py
+++ b/agentteams/framework_research.py
@@ -344,11 +344,33 @@ def propose_module_patch(repo_root: Path) -> dict[str, Any]:
     if not changes:
         return {"changes": [], "reason": "no drift to record"}
 
+    # Dedup signature: hash over upstream tokens + adapter constants only.
+    # Excludes generated_on and the rendered new_text so day-over-day runs
+    # with identical observations produce the SAME signature, letting the
+    # auto-PR workflow recognise "no real drift" and skip a duplicate PR.
+    import hashlib as _hashlib
+
+    dedup_payload = {
+        "frameworks": {
+            fid: {
+                "upstream_tokens": entry.get("upstream_tokens", {}),
+                "expected_keys": entry.get("expected_keys", []),
+            }
+            for fid, entry in frameworks.items()
+        },
+        "local_adapter": snapshot.get("local_adapter", {}),
+        "claude_keys_diff": snapshot.get("keys_diff", {}),
+    }
+    dedup_hash = _hashlib.sha256(
+        json.dumps(dedup_payload, sort_keys=True).encode()
+    ).hexdigest()[:12]
+
     return {
-        "schema_version": "1.1",
+        "schema_version": "1.2",
         "generated_at": _utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "snapshot_generated_on": snapshot.get("generated_on", ""),
         "frameworks": list(frameworks.keys()),
+        "dedup_hash": dedup_hash,
         "changes": changes,
     }
 
@@ -408,8 +430,13 @@ def _splice_observation_block(current: str, block: str, fid: str = "claude") -> 
         current = _LEGACY_OBSERVATION_RE.sub("", current, count=1)
     pat = _observation_re_for(fid)
     if pat.search(current):
-        return pat.sub("\n" + block.rstrip() + "\n", current, count=1).rstrip() + "\n"
-    return (current.rstrip() + "\n" + block).rstrip() + "\n"
+        out = pat.sub("\n" + block.rstrip() + "\n", current, count=1).rstrip() + "\n"
+    else:
+        out = (current.rstrip() + "\n" + block).rstrip() + "\n"
+    # Collapse any run of >=3 blank lines that the splice may have produced
+    # between adjacent sections to exactly one blank line. Prevents the
+    # blank-line accumulation observed in the daily auto-update PR diff.
+    return re.sub(r"\n{3,}", "\n\n", out)
 
 
 def apply_module_patch(proposal: dict[str, Any], repo_root: Path) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentteams"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "Generate a complete, coordinated AI agent team for any project from a single description file."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,15 @@ classifiers = [
 dependencies = ["jsonschema>=4.20"]
 keywords = ["agent", "ai", "copilot", "code-generation", "github-copilot", "llm", "multi-agent"]
 
+[project.optional-dependencies]
+# Tooling needed only to run the test suite. CI workflows install via
+# `pip install -e .[test]`. Adding to this list rather than to runtime
+# dependencies keeps the wheel small for end users.
+test = [
+    "pytest>=8",
+    "pyyaml>=6",
+]
+
 [project.urls]
 Homepage = "https://github.com/jlcatonjr/agentteams"
 Repository = "https://github.com/jlcatonjr/agentteams"

--- a/scripts/daily_pipeline_digest.py
+++ b/scripts/daily_pipeline_digest.py
@@ -93,6 +93,61 @@ def _bridge_summary_section() -> tuple[str, bool]:
     )
 
 
+def _operational_json_audit_section() -> tuple[str, bool]:
+    """T7/VI.1: detect generated `.github/agents/references/*.json` files
+    that look like operational metadata (high density of paths or
+    high-entropy tokens) but are NOT in scan._OPERATIONAL_JSON_NAMES.
+    Surfaces escapes from the suppression allow-list early so a future
+    new generated file can't silently re-block the daily security scan.
+    """
+    refs_dir = ROOT / ".github" / "agents" / "references"
+    if not refs_dir.is_dir():
+        return ("", False)
+    try:
+        from agentteams.scan import _OPERATIONAL_JSON_NAMES
+    except ImportError:
+        return ("", False)
+
+    import re as _re
+
+    path_re = _re.compile(r"/Users/|/home/|[A-Z]:\\\\")
+    hash_re = _re.compile(r'"[a-f0-9]{32,}"')
+    suspects: list[tuple[str, int, int]] = []
+    for jp in sorted(refs_dir.glob("*.json")):
+        if jp.name in _OPERATIONAL_JSON_NAMES:
+            continue
+        try:
+            lines = jp.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        if not lines:
+            continue
+        n_path = sum(1 for ln in lines if path_re.search(ln))
+        n_hash = sum(1 for ln in lines if hash_re.search(ln))
+        ratio = (n_path + n_hash) / max(1, len(lines))
+        if ratio > 0.05:
+            suspects.append((jp.name, n_path + n_hash, len(lines)))
+
+    if not suspects:
+        return ("", False)
+
+    lines = [
+        "## Operational-JSON allow-list audit",
+        "",
+        "Files matching the operational-metadata shape but NOT in",
+        "`agentteams.scan._OPERATIONAL_JSON_NAMES`. Review and add to",
+        "the allow-list if these are legitimate pipeline-controlled artefacts,",
+        "or scrub them if they leaked path/hash content unintentionally.",
+        "",
+        "| File | Flagged lines | Total lines |",
+        "|---|---|---|",
+    ]
+    for name, flagged, total in suspects:
+        lines.append(f"| `{name}` | {flagged} | {total} |")
+    lines.append("")
+    return ("\n".join(lines), True)
+
+
 def main(argv: list[str]) -> int:
     sections: list[str] = []
     any_active = False
@@ -101,6 +156,7 @@ def main(argv: list[str]) -> int:
         lambda: _per_day_section("shrink", "Fenced-region shrink events", "shrink-events"),
         lambda: _per_day_section("dual", "Dual-descriptor events", "dual-descriptor-events"),
         lambda: _per_day_section("orphan", "Orphan agent events", "orphan-events"),
+        _operational_json_audit_section,
         _bridge_summary_section,
     ):
         body, active = renderer()

--- a/tests/test_auto_update_workflow.py
+++ b/tests/test_auto_update_workflow.py
@@ -64,6 +64,16 @@ def test_workflow_minimal_permissions():
         f"expected exactly contents+pull-requests, got: {permission_lines}"
 
 
+def test_workflow_applies_supervised_labels():
+    """T5.2 / IV.2: auto-PRs must be labeled framework-update and
+    automerge:false so the operator can filter on the discovery surface
+    and so future reviewers can't confuse them with regular PRs.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert '--label "framework-update"' in text
+    assert '--label "automerge:false"' in text
+
+
 def test_workflow_targets_only_main_via_pr():
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "--base main" in text

--- a/tests/test_daily_pipeline_digest.py
+++ b/tests/test_daily_pipeline_digest.py
@@ -33,6 +33,43 @@ def test_no_inputs_no_digest(tmp_path, capsys, monkeypatch):
     assert "no active signals" in capsys.readouterr().out
 
 
+def test_operational_json_audit_flags_unknown_high_density(tmp_path, monkeypatch):
+    """VI.1: a non-allow-listed JSON file under .github/agents/references/
+    with >5% path/hash lines is flagged in the digest section.
+    """
+    mod = _run_with_root(tmp_path, monkeypatch)
+    refs = tmp_path / ".github" / "agents" / "references"
+    refs.mkdir(parents=True)
+    # 8 lines, 2 with path/hash content -> 25% density.
+    (refs / "weird-state.json").write_text(
+        '{\n'
+        '  "a": 1,\n'
+        '  "path": "/Users/op/data",\n'
+        '  "b": 2,\n'
+        '  "hash": "deadbeef0123456789abcdef0123456789abcdef0123",\n'
+        '  "c": 3,\n'
+        '  "d": 4,\n'
+        '}\n',
+        encoding="utf-8",
+    )
+    body, active = mod._operational_json_audit_section()
+    assert active
+    assert "weird-state.json" in body
+
+
+def test_operational_json_audit_silent_on_allowed(tmp_path, monkeypatch):
+    """VI.1: files inside _OPERATIONAL_JSON_NAMES never trigger the audit."""
+    mod = _run_with_root(tmp_path, monkeypatch)
+    refs = tmp_path / ".github" / "agents" / "references"
+    refs.mkdir(parents=True)
+    (refs / "memory-index.json").write_text(
+        '{\n  "path": "/Users/op/agentteams"\n}\n', encoding="utf-8"
+    )
+    body, active = mod._operational_json_audit_section()
+    assert not active
+    assert body == ""
+
+
 def test_with_inputs_writes_digest(tmp_path, capsys, monkeypatch):
     mod = _run_with_root(tmp_path, monkeypatch)
 

--- a/tests/test_framework_research.py
+++ b/tests/test_framework_research.py
@@ -190,3 +190,54 @@ def test_refresh_snapshot_offline_returns_cached(tmp_path, monkeypatch):
     snap = fr.refresh_snapshot(tmp_path, offline=True)
     assert snap.get("framework") == "claude"
     assert snap.get("generated_on") == "2026-05-25"
+
+
+def test_dedup_hash_stable_across_dates(tmp_path, monkeypatch):
+    """1.0.0-rc.2: proposal.dedup_hash must be identical across runs when
+    only generated_on differs (token-set unchanged). This is the property
+    the auto-PR dedup step relies on; if it breaks, the workflow opens a
+    fresh PR every day on no-drift days.
+    """
+    _write_minimal_module(tmp_path)
+    monkeypatch.setattr(fr, "_snapshot_path", lambda root: tmp_path / fr.SNAPSHOT_REL)
+    monkeypatch.delenv("CI", raising=False)
+
+    # Day 1.
+    _write_snapshot(tmp_path, with_drift=True)
+    snap_path = tmp_path / fr.SNAPSHOT_REL
+    p1 = fr.propose_module_patch(tmp_path)
+    h1 = p1.get("dedup_hash")
+    assert h1, "proposal must carry a dedup_hash"
+
+    # Day 2: same token-set, different generated_on.
+    body = json.loads(snap_path.read_text(encoding="utf-8"))
+    body["generated_on"] = "2026-05-26"
+    body["generated_at"] = "2026-05-26T00:00:00Z"
+    snap_path.write_text(json.dumps(body), encoding="utf-8")
+    p2 = fr.propose_module_patch(tmp_path)
+    h2 = p2.get("dedup_hash")
+    assert h1 == h2, f"dedup_hash drifted with date: {h1} vs {h2}"
+
+
+def test_splice_no_blank_line_accumulation():
+    """1.0.0-rc.2: repeated splice of the same heading must not grow
+    leading blank lines on each pass. Surfaced from PR #6's diff which
+    showed +1 blank line above the heading per day.
+    """
+    initial = (
+        "# Header\n\n"
+        "Some prose.\n\n"
+        "## Observed Upstream Tokens — `claude` (Daily Pipeline)\n\n"
+        "Old content.\n"
+    )
+    block = "\n## Observed Upstream Tokens — `claude` (Daily Pipeline)\n\nNew content.\n"
+    once = fr._splice_observation_block(initial, block, fid="claude")
+    twice = fr._splice_observation_block(once, block, fid="claude")
+    thrice = fr._splice_observation_block(twice, block, fid="claude")
+    # No run of 3+ consecutive newlines should appear.
+    import re as _re
+
+    assert not _re.search(r"\n{3,}", thrice), \
+        f"blank-line accumulation:\n{thrice!r}"
+    # And the body content stays exactly once.
+    assert thrice.count("New content.") == 1

--- a/tests/test_shrink_policy.py
+++ b/tests/test_shrink_policy.py
@@ -74,6 +74,26 @@ def test_halt_skips_write_and_records_blocked(tmp_path):
     assert "CVE-2024-DDDD" in body
 
 
+def test_dry_run_halt_preflight_lists_blocked_without_writing(tmp_path):
+    """T5.1 / IV.1: dry-run + halt populates shrink_blocked with the file
+    that a real run would refuse to write, without touching the file.
+    """
+    target = _setup(tmp_path)
+    original_bytes = target.read_bytes()
+    result = emit.emit_all(
+        [("demo.agent.md", NEW_RENDER)],
+        output_dir=tmp_path,
+        merge=True,
+        yes=True,
+        dry_run=True,
+        shrink_policy="halt",
+    )
+    assert result.notices
+    assert str(target) in result.shrink_blocked
+    # File must be byte-identical to before — dry-run never writes.
+    assert target.read_bytes() == original_bytes
+
+
 def test_allow_writes_silently(tmp_path):
     target = _setup(tmp_path)
     result = emit.emit_all(


### PR DESCRIPTION
## Summary

Soak release 1.0.0-rc.2. Six commits, all on disjoint surfaces so each was developable in parallel; sequenced sequentially this session.

### bugfixes
- `framework_research.propose_module_patch` emits a `dedup_hash` field over tokens + adapter constants only (schema 1.2). Workflow uses it instead of hashing the date-bearing `new_text`. **Stops daily noise PRs on no-drift days.**
- `_splice_observation_block` collapses runs of 3+ newlines; eliminates the per-day blank-line accumulation observed in PRs #5 and #6.

### additions
- `emit.emit_all(dry_run=True, shrink_policy="halt")` now pre-flights the block list into `EmitResult.shrink_blocked` without writing.
- Auto-PRs are labeled `framework-update` + `automerge:false` (labels created on the remote).
- `daily_pipeline_digest.py` adds an operational-JSON audit section: flags any `.github/agents/references/*.json` with >5% path/hash-density that is NOT in `scan._OPERATIONAL_JSON_NAMES`.
- `[project.optional-dependencies] test = ["pytest>=8", "pyyaml>=6"]`; CI uses `pip install -e ".[test]"`.

### version
- `pyproject.toml`: `1.0.0rc1` → `1.0.0rc2`.
- CHANGELOG: new `[1.0.0-rc.2] - 2026-05-27` section.

## Test plan
- [x] 930 tests pass locally (924 + 6 new in this branch).
- [x] RSR1 durable-tmp-refs lint: clean.
- [x] Man-page snapshot: current.
- [ ] CI green on this PR.
- [ ] Post-merge: confirm next scheduled `framework-auto-update` run on a no-drift day skips PR creation via dedup (the headline bugfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)