### PR TITLE
1.0.0-rc.3: agent-efficiency lints, terse-mode, daily-pipeline audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(no changes since 1.0.0-rc.2)
+(no changes since 1.0.0-rc.3)
+
+## [1.0.0-rc.3] - 2026-05-27
+
+Agent-efficiency release. Soak clock resets per pre-release
+convention; earliest defensible promotion to 1.0.0 final is now
+on or after 2026-06-03 (one week after rc.3).
+
+No public-API breaks since rc.2. New efficiency lints are
+advisory; the one template change (terse-mode directive) is
+additive and propagates to consumers via `--update --merge`.
+
+### added
+
+- **Per-agent token-budget + prompt-cache prefix lint
+  (`--check-budget`).** New `agentteams.budget` module audits live
+  `.agent.md` files for two efficiency dimensions. Budget warns
+  when a non-orchestrator agent exceeds 300 lines, fails at 600
+  lines (orchestrator-class fail threshold: 1000 lines). Prefix-
+  cache flags ISO-date patterns within the first 60 lines
+  outside HTML comments — volatile content in the prefix defeats
+  Anthropic prompt-cache hits on every refresh. CLI exits 1 on
+  fail-class findings, 0 on warn-class only.
+- **Daily-pipeline integration of the budget audit.**
+  `scripts/run_daily_bridge_maintenance.sh` invokes the audit as
+  a non-critical advisory step. Remediation routes to
+  `@agent-refactor` per the constitutional gate.
+- **Tone-and-style fence in the copilot-instructions template.**
+  Declares: read-only auditor and governance roles default to
+  ≤200-word responses; producing roles are explicitly exempt so
+  they aren't silenced when emitting deliverables. Reduces
+  consumer-harness token consumption on the common case of
+  audit-and-route turns.
+
+### fixed
+
+- **`conflict-auditor` template was over-scoped.** Its role
+  description says "Detects logical conflicts" — pure audit, with
+  routing to `@conflict-resolution` for the actual edits. The
+  template previously declared `['read', 'edit', 'search',
+  'execute']`. Trimmed to `['read', 'search']` to match the
+  contract. The new `tests/test_agent_tool_scopes.py` regression
+  keeps it honest across `security`, `adversarial`,
+  `code-hygiene`, and `conflict-auditor`.
+
+### tests added
+
+- `tests/test_budget.py` (9 cases).
+- `tests/test_agent_tool_scopes.py` (6 cases).
+- `tests/test_terse_mode_directive.py` (3 cases).
 
 ## [1.0.0-rc.2] - 2026-05-27
 

--- a/agentteams.1
+++ b/agentteams.1
@@ -2,7 +2,7 @@
 .SH NAME
 agentteams \- Generate a complete agent team for any project.
 .SH SYNOPSIS
-.B agentteams [--description PATH] [--project PATH] [--framework NAME] [--output DIR] [--dry-run] [--json] [--overwrite] [--merge] [--yes] [--no-scan] [--cost-routing] [--update] [--prune] [--check] [--refresh-index] [--query-index TEXT] [--query-k N] [--query-strategy QUERY_STRATEGY] [--fail-on-legacy-skip] [--scan-security] [--self] [--allow-external-self-output] [--post-audit] [--auto-correct] [--enrich] [--strict-manual-placeholders] [--no-strict-manual-placeholders STRICT_MANUAL_PLACEHOLDERS] [--security-offline] [--security-max-items N] [--security-no-nvd] [--migrate] [--convert-from DIR] [--interop-from DIR] [--interop-source-framework INTEROP_SOURCE_FRAMEWORK] [--interop-mode INTEROP_MODE] [--bridge-from DIR] [--bridge-source-framework BRIDGE_SOURCE_FRAMEWORK] [--bridge-check] [--bridge-refresh] [--bridge-merge] [--bridge-no-skills] [--revert-migration] [--version] [--no-backup] [--shrink-policy SHRINK_POLICY] [--list-backups] [--restore-backup TIMESTAMP] [--add-fence-markers PATH] [--in-place]
+.B agentteams [--description PATH] [--project PATH] [--framework NAME] [--output DIR] [--dry-run] [--json] [--overwrite] [--merge] [--yes] [--no-scan] [--cost-routing] [--update] [--prune] [--check] [--refresh-index] [--query-index TEXT] [--query-k N] [--query-strategy QUERY_STRATEGY] [--fail-on-legacy-skip] [--scan-security] [--check-budget] [--self] [--allow-external-self-output] [--post-audit] [--auto-correct] [--enrich] [--strict-manual-placeholders] [--no-strict-manual-placeholders STRICT_MANUAL_PLACEHOLDERS] [--security-offline] [--security-max-items N] [--security-no-nvd] [--migrate] [--convert-from DIR] [--interop-from DIR] [--interop-source-framework INTEROP_SOURCE_FRAMEWORK] [--interop-mode INTEROP_MODE] [--bridge-from DIR] [--bridge-source-framework BRIDGE_SOURCE_FRAMEWORK] [--bridge-check] [--bridge-refresh] [--bridge-merge] [--bridge-no-skills] [--revert-migration] [--version] [--no-backup] [--shrink-policy SHRINK_POLICY] [--list-backups] [--restore-backup TIMESTAMP] [--add-fence-markers PATH] [--in-place]
 .SH DESCRIPTION
 .PP
 Generate a complete agent team for any project.
@@ -71,6 +71,9 @@ Exit with non\-zero status if \-\-merge skipped any files due to missing fence m
 .TP
 .B \-\-scan\-security
 Scan generated agent files for security issues (PII, credentials, unresolved placeholders)
+.TP
+.B \-\-check\-budget
+Audit live .agent.md files for token\-budget overrun and prompt\-cache prefix volatility. Read\-only. Exits 1 on fail\-class findings; 0 on warn\-class only. Routes remediation to @agent\-refactor.
 .TP
 .B \-\-self
 Operate on the module's own agent team using .github/agents/_build\-description.json

--- a/agentteams/budget.py
+++ b/agentteams/budget.py
@@ -1,0 +1,159 @@
+"""budget.py — Agent-file efficiency lint (token-budget + cache-prefix shape).
+
+Read-only audit over the live `.agent.md` files. Two checks:
+
+1. **Token budget.** Estimates per-file token count (chars/4 heuristic; coarse
+   but stable across files). Warns when a file exceeds `BUDGET_WARN_LINES`
+   and fails when it exceeds `BUDGET_FAIL_LINES`. Orchestrator-class agents
+   get a higher budget (`ORCHESTRATOR_FAIL_LINES`) because they enumerate
+   the team. Tunable constants — change deliberately.
+
+2. **Prefix-cache friendliness.** Anthropic prompt caching keys on the
+   stable prefix of the prompt. Volatile content (timestamps, hashes,
+   per-run values) within the first `PREFIX_WINDOW_LINES` causes the
+   cache to miss on every refresh. Flags ISO-date patterns outside HTML
+   comments in the prefix window.
+
+Both checks are advisory — they emit findings; remediation goes to
+`@agent-refactor` per the constitutional gate.
+
+Plan: 3.1 + 3.4 from the 2026-05-27 efficiency review.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Tunable thresholds. Adjust deliberately; doc the rationale in CHANGELOG.
+# --------------------------------------------------------------------------
+
+#: Warn when a non-orchestrator agent file exceeds this many lines.
+#: Derived from current p75 size (~165 lines) + headroom.
+BUDGET_WARN_LINES = 300
+
+#: Fail when a non-orchestrator agent file exceeds this many lines.
+#: Picked to flag the current orchestrator (466 lines) as a one-off
+#: exception requiring the orchestrator carve-out below.
+BUDGET_FAIL_LINES = 600
+
+#: Orchestrator-class fail threshold (the orchestrator enumerates the team).
+ORCHESTRATOR_FAIL_LINES = 1000
+
+#: Lines inspected for prefix-cache friendliness. The first 60 lines
+#: typically contain front matter + identity + role description — the
+#: portion that benefits most from caching.
+PREFIX_WINDOW_LINES = 60
+
+#: Coarse char-to-token ratio used for the budget estimate.
+CHARS_PER_TOKEN = 4
+
+_ISO_DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+@dataclass
+class BudgetFinding:
+    """One advisory finding about an agent file."""
+    file: str
+    category: str  # "budget-warn" | "budget-fail" | "prefix-volatile"
+    severity: str  # "warn" | "fail"
+    message: str
+
+
+@dataclass
+class BudgetReport:
+    """Aggregate of all budget findings."""
+    scanned_files: int = 0
+    findings: list[BudgetFinding] = field(default_factory=list)
+
+    @property
+    def has_failures(self) -> bool:
+        return any(f.severity == "fail" for f in self.findings)
+
+
+def _is_orchestrator(rel_path: str) -> bool:
+    return rel_path.endswith("orchestrator.agent.md")
+
+
+def _strip_html_comments(text: str) -> str:
+    return _HTML_COMMENT_RE.sub("", text)
+
+
+def _check_budget(rel_path: str, lines: list[str], chars: int, findings: list[BudgetFinding]) -> None:
+    """3.1 — file-size budget."""
+    n = len(lines)
+    fail_thresh = ORCHESTRATOR_FAIL_LINES if _is_orchestrator(rel_path) else BUDGET_FAIL_LINES
+    approx_tokens = chars // CHARS_PER_TOKEN
+    if n > fail_thresh:
+        findings.append(BudgetFinding(
+            file=rel_path,
+            category="budget-fail",
+            severity="fail",
+            message=f"{n} lines (~{approx_tokens} tokens) exceeds fail threshold {fail_thresh}",
+        ))
+    elif n > BUDGET_WARN_LINES and not _is_orchestrator(rel_path):
+        findings.append(BudgetFinding(
+            file=rel_path,
+            category="budget-warn",
+            severity="warn",
+            message=f"{n} lines (~{approx_tokens} tokens) exceeds warn threshold {BUDGET_WARN_LINES}",
+        ))
+
+
+def _check_prefix_cache(rel_path: str, lines: list[str], findings: list[BudgetFinding]) -> None:
+    """3.4 — prefix-cache friendliness: no volatile dates in first PREFIX_WINDOW_LINES."""
+    prefix = "\n".join(lines[:PREFIX_WINDOW_LINES])
+    cleaned = _strip_html_comments(prefix)
+    matches = _ISO_DATE_RE.findall(cleaned)
+    if matches:
+        sample = matches[:3]
+        more = f" (+{len(matches) - 3} more)" if len(matches) > 3 else ""
+        findings.append(BudgetFinding(
+            file=rel_path,
+            category="prefix-volatile",
+            severity="warn",
+            message=(
+                f"ISO-date(s) within first {PREFIX_WINDOW_LINES} lines outside HTML comments: "
+                f"{', '.join(sample)}{more}. Move to a fenced section lower in the file "
+                f"or wrap in an HTML comment to preserve prompt-cache hits."
+            ),
+        ))
+
+
+def scan_directory(agents_dir: Path) -> BudgetReport:
+    """Audit every `*.agent.md` file directly under `agents_dir` (not recursive).
+
+    Skips `.agentteams-backups/` by virtue of being non-recursive.
+    """
+    report = BudgetReport()
+    if not agents_dir.is_dir():
+        return report
+
+    for agent_file in sorted(agents_dir.glob("*.agent.md")):
+        try:
+            content = agent_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        lines = content.splitlines()
+        rel = agent_file.name
+        report.scanned_files += 1
+        _check_budget(rel, lines, len(content), report.findings)
+        _check_prefix_cache(rel, lines, report.findings)
+    return report
+
+
+def print_report(report: BudgetReport) -> None:
+    """Human-readable summary for CLI / daily-pipeline log."""
+    print(f"Agent-budget scan: {report.scanned_files} file(s)")
+    if not report.findings:
+        print("  ✓ No findings.")
+        return
+    warns = sum(1 for f in report.findings if f.severity == "warn")
+    fails = sum(1 for f in report.findings if f.severity == "fail")
+    print(f"  {fails} fail, {warns} warn")
+    for f in report.findings:
+        marker = "✗" if f.severity == "fail" else "⚠"
+        print(f"  {marker} {f.file} [{f.category}] {f.message}")

--- a/agentteams/templates/copilot-instructions.template.md
+++ b/agentteams/templates/copilot-instructions.template.md
@@ -84,6 +84,25 @@ SECTION MANIFEST — copilot-instructions.template.md
 
 ---
 
+<!-- AGENTTEAMS:BEGIN tone_and_style v=1 -->
+## Tone and Style
+
+Default to terse output for read-only auditor and governance roles
+(`@security`, `@adversarial`, `@code-hygiene`, `@conflict-auditor`,
+`@navigator`, `@quality-auditor`, `@technical-validator`,
+`@post-production-auditor`, `@module-doc-validator`,
+`@reference-manager` in read mode): respond in ≤200 words unless
+the task requires longer output. Producing roles
+(`@primary-producer`, `@module-doc-author`, `@content-enricher`,
+`@output-compiler`, `@orchestrator` when summarizing a multi-step
+session) emit the deliverable in full and are exempt from this
+default.
+
+Terse mode reduces consumer-harness token consumption on the
+common case of audit-and-route turns. Producing roles override the
+default explicitly by saying so in their first line.
+<!-- AGENTTEAMS:END tone_and_style -->
+
 <!-- AGENTTEAMS:BEGIN authority_hierarchy v=1 -->
 ## Authority Hierarchy
 

--- a/agentteams/templates/universal/conflict-auditor.template.md
+++ b/agentteams/templates/universal/conflict-auditor.template.md
@@ -2,7 +2,7 @@
 name: Conflict Auditor — {PROJECT_NAME}
 description: "Detects logical conflicts across deliverables, agent documentation, reference files, and source material in {PROJECT_NAME}"
 user-invokable: false
-tools: ['read', 'edit', 'search', 'execute']
+tools: ['read', 'search']
 agents: ['conflict-resolution', 'agent-updater', 'technical-validator']
 model: ["Claude Sonnet 4.6 (copilot)"]
 handoffs:

--- a/build_team.py
+++ b/build_team.py
@@ -291,6 +291,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Scan generated agent files for security issues (PII, credentials, unresolved placeholders)",
     )
     parser.add_argument(
+        "--check-budget",
+        action="store_true",
+        dest="check_budget",
+        help=(
+            "Audit live .agent.md files for token-budget overrun and "
+            "prompt-cache prefix volatility. Read-only. Exits 1 on fail-class "
+            "findings; 0 on warn-class only. Routes remediation to @agent-refactor."
+        ),
+    )
+    parser.add_argument(
         "--self",
         action="store_true",
         dest="self_update",
@@ -1073,6 +1083,15 @@ def main(argv: list[str] | None = None) -> int:
         report = scan.scan_directory(output_dir, expected_agent_names=expected or None)
         scan.print_scan_report(report)
         return 1 if report.has_issues else 0
+
+    # -----------------------------------------------------------------------
+    # Step 4b.2: Handle --check-budget (3.1 + 3.4 efficiency lints)
+    # -----------------------------------------------------------------------
+    if args.check_budget:
+        from agentteams import budget
+        breport = budget.scan_directory(output_dir)
+        budget.print_report(breport)
+        return 1 if breport.has_failures else 0
 
     # -----------------------------------------------------------------------
     # Step 4c: Handle memory-index utility modes (no template rendering)

--- a/examples/data-pipeline/expected/conflict-auditor.agent.md
+++ b/examples/data-pipeline/expected/conflict-auditor.agent.md
@@ -2,7 +2,7 @@
 name: Conflict Auditor — SalesDataPipeline
 description: "Detects logical conflicts across deliverables, agent documentation, reference files, and source material in SalesDataPipeline"
 user-invokable: false
-tools: ['read', 'edit', 'search', 'execute']
+tools: ['read', 'search']
 agents: ['conflict-resolution', 'agent-updater', 'technical-validator']
 model: ["Claude Sonnet 4.6 (copilot)"]
 handoffs:

--- a/examples/data-pipeline/expected/references/pipeline-graph.md
+++ b/examples/data-pipeline/expected/references/pipeline-graph.md
@@ -238,7 +238,7 @@ flowchart LR
 | `cleanup` | governance | No | edit, search, execute |
 | `code-hygiene` | governance | No | read, search |
 | `cohesion-repairer` | domain | No | read, edit |
-| `conflict-auditor` | governance | No | read, edit, search, execute |
+| `conflict-auditor` | governance | No | read, search |
 | `conflict-resolution` | governance | No | edit, search, read |
 | `content-enricher` | domain | Yes | read, edit, search |
 | `format-converter` | domain | No | read, edit, execute |
@@ -516,9 +516,7 @@ digraph "SalesDataPipeline Agent Team" {
       "user_invokable": false,
       "tools": [
         "read",
-        "edit",
-        "search",
-        "execute"
+        "search"
       ]
     },
     "conflict-resolution": {

--- a/examples/project-repositories/expected/conflict-auditor.agent.md
+++ b/examples/project-repositories/expected/conflict-auditor.agent.md
@@ -2,7 +2,7 @@
 name: Conflict Auditor — ProjectRepositories
 description: "Detects logical conflicts across deliverables, agent documentation, reference files, and source material in ProjectRepositories"
 user-invokable: false
-tools: ['read', 'edit', 'search', 'execute']
+tools: ['read', 'search']
 agents: ['conflict-resolution', 'agent-updater', 'technical-validator']
 model: ["Claude Sonnet 4.6 (copilot)"]
 handoffs:

--- a/examples/project-repositories/expected/references/pipeline-graph.md
+++ b/examples/project-repositories/expected/references/pipeline-graph.md
@@ -256,7 +256,7 @@ flowchart LR
 | `cleanup` | governance | No | edit, search, execute |
 | `code-hygiene` | governance | No | read, search |
 | `cohesion-repairer` | domain | No | read, edit |
-| `conflict-auditor` | governance | No | read, edit, search, execute |
+| `conflict-auditor` | governance | No | read, search |
 | `conflict-resolution` | governance | No | edit, search, read |
 | `content-enricher` | domain | Yes | read, edit, search |
 | `crisis-credit-allocation-expert` | workstream_expert | No | read, search, agent |
@@ -544,9 +544,7 @@ digraph "ProjectRepositories Agent Team" {
       "user_invokable": false,
       "tools": [
         "read",
-        "edit",
-        "search",
-        "execute"
+        "search"
       ]
     },
     "conflict-resolution": {

--- a/examples/research-project/expected/conflict-auditor.agent.md
+++ b/examples/research-project/expected/conflict-auditor.agent.md
@@ -2,7 +2,7 @@
 name: Conflict Auditor — ResearchPaperProject
 description: "Detects logical conflicts across deliverables, agent documentation, reference files, and source material in ResearchPaperProject"
 user-invokable: false
-tools: ['read', 'edit', 'search', 'execute']
+tools: ['read', 'search']
 agents: ['conflict-resolution', 'agent-updater', 'technical-validator']
 model: ["Claude Sonnet 4.6 (copilot)"]
 handoffs:

--- a/examples/research-project/expected/references/pipeline-graph.md
+++ b/examples/research-project/expected/references/pipeline-graph.md
@@ -250,7 +250,7 @@ flowchart LR
 | `cleanup` | governance | No | edit, search, execute |
 | `code-hygiene` | governance | No | read, search |
 | `cohesion-repairer` | domain | No | read, edit |
-| `conflict-auditor` | governance | No | read, edit, search, execute |
+| `conflict-auditor` | governance | No | read, search |
 | `conflict-resolution` | governance | No | edit, search, read |
 | `content-enricher` | domain | Yes | read, edit, search |
 | `format-converter` | domain | No | read, edit, execute |
@@ -552,9 +552,7 @@ digraph "ResearchPaperProject Agent Team" {
       "user_invokable": false,
       "tools": [
         "read",
-        "edit",
-        "search",
-        "execute"
+        "search"
       ]
     },
     "conflict-resolution": {

--- a/examples/software-project/expected/conflict-auditor.agent.md
+++ b/examples/software-project/expected/conflict-auditor.agent.md
@@ -2,7 +2,7 @@
 name: Conflict Auditor — WebAppBackend
 description: "Detects logical conflicts across deliverables, agent documentation, reference files, and source material in WebAppBackend"
 user-invokable: false
-tools: ['read', 'edit', 'search', 'execute']
+tools: ['read', 'search']
 agents: ['conflict-resolution', 'agent-updater', 'technical-validator']
 model: ["Claude Sonnet 4.6 (copilot)"]
 handoffs:

--- a/examples/software-project/expected/references/pipeline-graph.md
+++ b/examples/software-project/expected/references/pipeline-graph.md
@@ -203,7 +203,7 @@ flowchart LR
 | `cleanup` | governance | No | edit, search, execute |
 | `code-hygiene` | governance | No | read, search |
 | `cohesion-repairer` | domain | No | read, edit |
-| `conflict-auditor` | governance | No | read, edit, search, execute |
+| `conflict-auditor` | governance | No | read, search |
 | `conflict-resolution` | governance | No | edit, search, read |
 | `content-enricher` | domain | Yes | read, edit, search |
 | `format-converter` | domain | No | read, edit, execute |
@@ -459,9 +459,7 @@ digraph "WebAppBackend Agent Team" {
       "user_invokable": false,
       "tools": [
         "read",
-        "edit",
-        "search",
-        "execute"
+        "search"
       ]
     },
     "conflict-resolution": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentteams"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 description = "Generate a complete, coordinated AI agent team for any project from a single description file."
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/run_daily_bridge_maintenance.sh
+++ b/scripts/run_daily_bridge_maintenance.sh
@@ -69,6 +69,14 @@ if [[ -f "$RESEARCH_SCRIPT" ]]; then
     "Module-core update proposal (advisory)" \
     python "$RESEARCH_SCRIPT" --propose
 
+  # 3.1 + 3.4 from the 2026-05-27 efficiency review: per-agent token-budget
+  # and prompt-cache prefix lint. Advisory only; remediation routes to
+  # @agent-refactor per the constitutional gate. Run on self-team so the
+  # daily-pipeline tracks our own agent-file efficiency drift.
+  run_noncritical \
+    "Self-team agent-budget audit (advisory)" \
+    python build_team.py --self --yes --check-budget --security-offline --security-no-nvd
+
   DIGEST_SCRIPT="$ROOT_DIR/scripts/daily_pipeline_digest.py"
   if [[ -f "$DIGEST_SCRIPT" ]]; then
     run_noncritical \

--- a/tests/test_agent_tool_scopes.py
+++ b/tests/test_agent_tool_scopes.py
@@ -1,0 +1,67 @@
+"""Tests for read-only-auditor tool scope (3.3 from the 2026-05-27 efficiency review).
+
+Audits agent templates whose role descriptions assert read-only behaviour
+('detects', 'reviews', 'audits', 'enforces' without 'rewrites') and asserts
+their declared tools omit write/execute capabilities. Tighter scoping
+reduces tool-schema tokens that the consumer harness loads at runtime.
+
+The list is curated, not derived from the description — a heuristic
+extractor would mis-classify edge cases. New auditor-class templates
+should be added to READ_ONLY_AGENT_TEMPLATES with the same audit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "agentteams" / "templates" / "universal"
+
+# Curated list of templates whose declared role is pure audit. Adding a new
+# entry asserts the contract; removing one requires a description-text update
+# explaining why writes are necessary.
+READ_ONLY_AGENT_TEMPLATES = (
+    "security",
+    "adversarial",
+    "code-hygiene",
+    "conflict-auditor",
+)
+
+# Tools that mutate the working tree or invoke shell. Any of these in a
+# read-only agent's tool list is a contract violation.
+WRITE_CLASS_TOOLS = frozenset({"edit", "execute", "write"})
+
+_TOOLS_LINE_RE = re.compile(r"^tools:\s*\[(.*?)\]\s*$", re.MULTILINE)
+_TOKEN_RE = re.compile(r"'([^']+)'|\"([^\"]+)\"")
+
+
+def _parse_tools(template_text: str) -> list[str]:
+    m = _TOOLS_LINE_RE.search(template_text)
+    if not m:
+        return []
+    return [a or b for a, b in _TOKEN_RE.findall(m.group(1))]
+
+
+@pytest.mark.parametrize("slug", READ_ONLY_AGENT_TEMPLATES)
+def test_read_only_agent_declares_no_write_tools(slug):
+    tpl = TEMPLATES_DIR / f"{slug}.template.md"
+    assert tpl.exists(), f"missing template: {tpl}"
+    tools = _parse_tools(tpl.read_text(encoding="utf-8"))
+    write_tools = set(tools) & WRITE_CLASS_TOOLS
+    assert not write_tools, (
+        f"{slug} is in READ_ONLY_AGENT_TEMPLATES but declares write-class "
+        f"tools {sorted(write_tools)}. Either remove the over-scoped tools "
+        f"or update the role description and drop {slug} from the read-only "
+        f"set."
+    )
+
+
+def test_parse_tools_handles_single_and_double_quotes():
+    assert _parse_tools("tools: ['read', 'search']\n") == ["read", "search"]
+    assert _parse_tools('tools: ["read", "search"]\n') == ["read", "search"]
+
+
+def test_parse_tools_returns_empty_when_no_tools_line():
+    assert _parse_tools("name: x\ndescription: y\n") == []

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,87 @@
+"""Tests for agentteams.budget (3.1 + 3.4 efficiency lints)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentteams import budget
+
+
+def _write_agent(tmp_path: Path, name: str, lines: int, *, prefix_date: bool = False, html_comment_date: bool = False) -> Path:
+    p = tmp_path / name
+    body_lines = ["---", "name: x", "description: y", "---", ""]
+    if prefix_date:
+        body_lines.append("Recorded on 2026-05-27.")
+    if html_comment_date:
+        body_lines.append("<!-- generated: 2026-05-27 -->")
+    body_lines.extend([f"Line {i}" for i in range(lines)])
+    p.write_text("\n".join(body_lines), encoding="utf-8")
+    return p
+
+
+def test_small_agent_no_findings(tmp_path):
+    _write_agent(tmp_path, "small.agent.md", 50)
+    report = budget.scan_directory(tmp_path)
+    assert report.scanned_files == 1
+    assert report.findings == []
+    assert not report.has_failures
+
+
+def test_warn_threshold_fires(tmp_path):
+    _write_agent(tmp_path, "biggish.agent.md", budget.BUDGET_WARN_LINES + 5)
+    report = budget.scan_directory(tmp_path)
+    cats = {f.category for f in report.findings}
+    assert "budget-warn" in cats
+    # Warn-only must not fail the report.
+    assert not report.has_failures
+
+
+def test_fail_threshold_fires(tmp_path):
+    _write_agent(tmp_path, "huge.agent.md", budget.BUDGET_FAIL_LINES + 5)
+    report = budget.scan_directory(tmp_path)
+    cats = {(f.category, f.severity) for f in report.findings}
+    assert ("budget-fail", "fail") in cats
+    assert report.has_failures
+
+
+def test_orchestrator_gets_higher_budget(tmp_path):
+    # 700 lines: above BUDGET_FAIL_LINES (600) but under ORCHESTRATOR_FAIL_LINES (1000).
+    _write_agent(tmp_path, "orchestrator.agent.md", 700)
+    report = budget.scan_directory(tmp_path)
+    # Non-orchestrator would have produced a budget-fail at 700 lines;
+    # orchestrator must not.
+    fails = [f for f in report.findings if f.severity == "fail"]
+    assert fails == []
+
+
+def test_orchestrator_can_still_fail(tmp_path):
+    _write_agent(tmp_path, "orchestrator.agent.md", budget.ORCHESTRATOR_FAIL_LINES + 10)
+    report = budget.scan_directory(tmp_path)
+    assert report.has_failures
+
+
+def test_prefix_volatile_date_flagged(tmp_path):
+    _write_agent(tmp_path, "stamped.agent.md", 30, prefix_date=True)
+    report = budget.scan_directory(tmp_path)
+    cats = {f.category for f in report.findings}
+    assert "prefix-volatile" in cats
+
+
+def test_prefix_date_in_html_comment_is_exempt(tmp_path):
+    _write_agent(tmp_path, "stamped.agent.md", 30, html_comment_date=True)
+    report = budget.scan_directory(tmp_path)
+    cats = {f.category for f in report.findings}
+    assert "prefix-volatile" not in cats
+
+
+def test_skips_non_agent_md_files(tmp_path):
+    (tmp_path / "readme.md").write_text("# x\n", encoding="utf-8")
+    _write_agent(tmp_path, "agent.agent.md", 30)
+    report = budget.scan_directory(tmp_path)
+    assert report.scanned_files == 1
+
+
+def test_missing_dir_returns_empty(tmp_path):
+    report = budget.scan_directory(tmp_path / "does-not-exist")
+    assert report.scanned_files == 0
+    assert report.findings == []

--- a/tests/test_terse_mode_directive.py
+++ b/tests/test_terse_mode_directive.py
@@ -1,0 +1,48 @@
+"""Tests for the tone_and_style fence in copilot-instructions.template.md (3.5).
+
+The terse-mode directive is a fenced section so consumer repos pick it up
+via `--update --merge`. The test asserts the fence exists with the expected
+shape and lists the read-only auditor roles by slug.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "agentteams"
+    / "templates"
+    / "copilot-instructions.template.md"
+)
+
+_FENCE_RE = re.compile(
+    r"<!-- AGENTTEAMS:BEGIN tone_and_style v=\d+ -->.*?"
+    r"<!-- AGENTTEAMS:END tone_and_style -->",
+    re.DOTALL,
+)
+
+
+def test_tone_and_style_fence_present():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert _FENCE_RE.search(text), "tone_and_style fence missing from copilot-instructions template"
+
+
+def test_tone_and_style_names_read_only_agents():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    m = _FENCE_RE.search(text)
+    assert m is not None
+    body = m.group(0)
+    # Sample the read-only set that test_agent_tool_scopes already audits.
+    for agent in ("@security", "@adversarial", "@code-hygiene", "@conflict-auditor"):
+        assert agent in body, f"terse-mode block must list {agent}"
+
+
+def test_tone_and_style_exempts_producers():
+    """Producing roles must be explicitly exempt so they aren't silenced."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    m = _FENCE_RE.search(text)
+    body = m.group(0)
+    for producer in ("@primary-producer", "@module-doc-author"):
+        assert producer in body, f"terse-mode block must list {producer} as exempt producer"


### PR DESCRIPTION
## Summary

Five commits implementing 3.1, 3.3, 3.4, 3.5 from the 2026-05-27 efficiency review. Each commit touches a disjoint surface; sequenced in this PR but parallelizable in principle.

### features
- **3.1 + 3.4** `--check-budget` CLI flag and `agentteams.budget` module — per-file token budget + prompt-cache prefix lint. Daily-pipeline integration as non-critical advisory.
- **3.3** `tests/test_agent_tool_scopes.py` regression over read-only auditor templates. Surfaced + fixed conflict-auditor's over-scoped tools.
- **3.5** New `tone_and_style` fenced section in `copilot-instructions.template.md`. Read-only agents default to ≤200-word responses; producers exempt.

### daily-pipeline refactor coverage
The user's framing question: does the daily pipeline include a refactor of agent-architecture documents? Before this branch: no. After this branch: a non-critical lint runs on every daily fire and surfaces refactor candidates. Remediation routes to `@agent-refactor` per the constitutional gate (advisory only — never auto-modifies).

### versioning
- `pyproject.toml`: `1.0.0rc2` → `1.0.0rc3`.
- CHANGELOG: new `[1.0.0-rc.3] - 2026-05-27` section.
- Soak clock resets per pre-release convention; earliest promotion to 1.0.0 final on or after 2026-06-03.

## Test plan
- [x] 948 tests pass locally (930 + 18 new).
- [x] RSR1 lint clean.
- [x] Man-page refreshed for `--check-budget`.
- [x] Live exercise of `--check-budget` on self-team: clean.
- [x] Live exercise of `--self --update --merge`: terse-mode fence propagated to `.github/copilot-instructions.md`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)