### PR TITLE
1.0.0-rc.4: daily-pipeline auto-merges + post-execution report

### DIFF
--- a/.github/workflows/framework-auto-update.yml
+++ b/.github/workflows/framework-auto-update.yml
@@ -126,10 +126,36 @@ jobs:
             echo
             echo "Hash: \`$PHASH\`"
           } > "$body_file"
-          gh pr create \
+          # rc.4: the daily pipeline implements revisions automatically.
+          # PRs created by GITHUB_TOKEN do not trigger CI (GitHub's
+          # infinite-loop safeguard), so there is no CI to gate on; merge
+          # immediately. Branch protection still requires a PR (we just
+          # made one); 0 required approvals lets the workflow merge its
+          # own. The merge commit on main fires the normal CI run, which
+          # is the post-merge safety net.
+          pr_url=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "auto: framework upstream-token observation ($PHASH)" \
             --body-file "$body_file" \
-            --label "framework-update" \
-            --label "automerge:false"
+            --label "framework-update")
+          pr_num=$(basename "$pr_url")
+          echo "Opened PR: $pr_url"
+
+          gh pr merge "$pr_num" --merge --delete-branch
+          merged_sha=$(gh pr view "$pr_num" --json mergeCommit --jq '.mergeCommit.oid')
+          echo "Merged as $merged_sha"
+
+          # rc.4 post-execution report: emit a step summary so the run
+          # log records exactly what landed on main this cycle.
+          {
+            echo "## Auto-update execution report"
+            echo
+            echo "- PR: $pr_url"
+            echo "- Hash: \`$PHASH\`"
+            echo "- Merge commit: \`$merged_sha\`"
+            echo "- Branch: \`$BRANCH\` (deleted)"
+            echo
+            echo "### Diff scope"
+            gh pr diff "$pr_num" --color never | head -200
+          } >> "$GITHUB_STEP_SUMMARY" || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(no changes since 1.0.0-rc.3)
+(no changes since 1.0.0-rc.4)
+
+## [1.0.0-rc.4] - 2026-05-27
+
+Auto-merge release. The daily pipeline now implements revisions
+automatically rather than waiting for a human merge action. Soak
+clock resets per pre-release convention; earliest defensible
+promotion to 1.0.0 final is now on or after 2026-06-03 (one week
+after rc.4).
+
+No public-API breaks since rc.3.
+
+### changed
+
+- **`framework-auto-update.yml` auto-merges its own PR.** The
+  workflow now runs `gh pr merge --merge --delete-branch`
+  immediately after `gh pr create`. PRs created by `GITHUB_TOKEN`
+  do not trigger CI (GitHub's infinite-loop safeguard), so there
+  is no CI gate to await; the merge commit on `main` fires the
+  normal CI run, which is the post-merge safety net. Branch
+  protection on `main` is unchanged — the workflow merges through
+  the same PR surface that a human would. Reversibility: standard
+  `git revert` of the merge commit.
+- **`automerge:false` label dropped** from auto-PRs. The label
+  conflicted with the new behaviour; `framework-update` remains
+  for discovery filtering.
+
+### added
+
+- **Post-execution report via `GITHUB_STEP_SUMMARY`.** Each
+  `framework-auto-update` run emits a step summary listing the PR
+  URL, proposal hash, merge commit SHA, and the merged diff
+  (first 200 lines). Recorded in the GitHub Actions run UI so
+  every cycle has an auditable "what landed today" surface.
 
 ## [1.0.0-rc.3] - 2026-05-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentteams"
-version = "1.0.0rc3"
+version = "1.0.0rc4"
 description = "Generate a complete, coordinated AI agent team for any project from a single description file."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_auto_update_workflow.py
+++ b/tests/test_auto_update_workflow.py
@@ -64,14 +64,37 @@ def test_workflow_minimal_permissions():
         f"expected exactly contents+pull-requests, got: {permission_lines}"
 
 
-def test_workflow_applies_supervised_labels():
-    """T5.2 / IV.2: auto-PRs must be labeled framework-update and
-    automerge:false so the operator can filter on the discovery surface
-    and so future reviewers can't confuse them with regular PRs.
+def test_workflow_applies_framework_update_label():
+    """T5.2 / IV.2 + rc.4: auto-PRs must be labeled framework-update so
+    the operator can filter on the discovery surface. The automerge:false
+    label was removed in rc.4 when the daily pipeline began implementing
+    revisions automatically; the workflow now merges its own PR
+    immediately after creation.
     """
     text = WORKFLOW.read_text(encoding="utf-8")
     assert '--label "framework-update"' in text
-    assert '--label "automerge:false"' in text
+    assert '--label "automerge:false"' not in text, (
+        "rc.4 removed the automerge:false label; the workflow auto-merges its own PR"
+    )
+
+
+def test_workflow_auto_merges_its_own_pr():
+    """rc.4: the workflow runs `gh pr merge` immediately after creating
+    the PR. CI does not fire on GITHUB_TOKEN-created PRs (GitHub's
+    infinite-loop safeguard), so there is no CI gate to await.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert 'gh pr merge "$pr_num" --merge --delete-branch' in text
+
+
+def test_workflow_emits_post_execution_step_summary():
+    """rc.4: GITHUB_STEP_SUMMARY captures the PR URL, hash, merge commit,
+    and the merged diff so each run log records exactly what landed on main.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert 'GITHUB_STEP_SUMMARY' in text
+    assert 'Auto-update execution report' in text
+    assert 'gh pr diff' in text
 
 
 def test_workflow_targets_only_main_via_pr():


### PR DESCRIPTION
## Summary

rc.4 closes the supervised auto-PR loop into a fully automatic loop. The framework-auto-update workflow now merges its own PR immediately after creation; every run emits a post-execution step summary to GITHUB_STEP_SUMMARY listing what landed on main.

### changed
- `framework-auto-update.yml` runs `gh pr merge --merge --delete-branch` after `gh pr create`. PRs created by GITHUB_TOKEN don't trigger CI (GitHub safeguard against infinite loops), so there's no CI gate to await; the merge commit on main fires the normal CI run, which is the post-merge safety net.
- Branch protection on main unchanged — the workflow merges through the same PR surface a human would.
- `automerge:false` label dropped from auto-PRs (it conflicted with the new behaviour).

### added
- `GITHUB_STEP_SUMMARY` captures PR URL, proposal hash, merge commit SHA, and first 200 lines of the merged diff.

## Reversibility
Standard `git revert` of any merge commit. Each merge is a separate, named SHA.

## Test plan
- [x] 950 tests pass locally.
- [x] RSR1 lint clean.
- [x] Man-page current.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)