### PR TITLE
1.0.0-rc.5: dispatch CI after auto-merge + drift-detector audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - "v*"
   pull_request:
+  # rc.5: workflow_dispatch is exempt from the GITHUB_TOKEN infinite-loop
+  # safeguard, so framework-auto-update.yml can dispatch CI on the
+  # auto-merge commit and restore the rc.4 post-merge safety-net claim.
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/framework-auto-update.yml
+++ b/.github/workflows/framework-auto-update.yml
@@ -128,11 +128,10 @@ jobs:
           } > "$body_file"
           # rc.4: the daily pipeline implements revisions automatically.
           # PRs created by GITHUB_TOKEN do not trigger CI (GitHub's
-          # infinite-loop safeguard), so there is no CI to gate on; merge
-          # immediately. Branch protection still requires a PR (we just
-          # made one); 0 required approvals lets the workflow merge its
-          # own. The merge commit on main fires the normal CI run, which
-          # is the post-merge safety net.
+          # infinite-loop safeguard), nor does the merge event itself.
+          # rc.5 closes the resulting safety-net gap by explicitly
+          # dispatching ci.yml against main after the merge —
+          # workflow_dispatch is exempt from the GITHUB_TOKEN filter.
           pr_url=$(gh pr create \
             --base main \
             --head "$BRANCH" \
@@ -146,6 +145,20 @@ jobs:
           merged_sha=$(gh pr view "$pr_num" --json mergeCommit --jq '.mergeCommit.oid')
           echo "Merged as $merged_sha"
 
+          # rc.5: dispatch CI on main so the broader test matrix runs
+          # against the auto-merge commit. The dispatched run is the
+          # restored post-merge safety net (rc.4 claimed this happened
+          # via the normal push trigger; it does not, due to
+          # GITHUB_TOKEN filtering).
+          ci_run_url=""
+          if gh workflow run ci.yml --ref main; then
+            sleep 3
+            ci_run_url=$(gh run list --workflow=ci.yml --limit 1 --json url --jq '.[0].url' || true)
+            echo "Dispatched CI: $ci_run_url"
+          else
+            echo "WARN: CI dispatch failed; the auto-merge landed but post-merge CI did not fire" >&2
+          fi
+
           # rc.4 post-execution report: emit a step summary so the run
           # log records exactly what landed on main this cycle.
           {
@@ -155,6 +168,7 @@ jobs:
             echo "- Hash: \`$PHASH\`"
             echo "- Merge commit: \`$merged_sha\`"
             echo "- Branch: \`$BRANCH\` (deleted)"
+            echo "- Post-merge CI: $ci_run_url"
             echo
             echo "### Diff scope"
             gh pr diff "$pr_num" --color never | head -200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(no changes since 1.0.0-rc.4)
+(no changes since 1.0.0-rc.5)
+
+## [1.0.0-rc.5] - 2026-05-27
+
+Post-merge safety net restored. Drift-detector inventory audited.
+Soak clock resets per pre-release convention; earliest defensible
+promotion to 1.0.0 final is now on or after 2026-06-03 (one week
+after rc.5).
+
+No public-API breaks since rc.4.
+
+### fixed
+
+- **`framework-auto-update.yml` now dispatches `ci.yml` after the
+  auto-merge.** Production test of rc.4 (workflow run 26518916462,
+  merge commit `25afe9f`) revealed that the rc.4 CHANGELOG claim
+  "the merge commit on main fires the normal CI run, which is the
+  post-merge safety net" was wrong: GitHub's GITHUB_TOKEN
+  infinite-loop safeguard suppresses workflow runs caused by
+  GITHUB_TOKEN events, including the merge event itself.
+  Empirical: `gh api .../commits/25afe9f/check-runs` returned
+  empty. rc.5 closes the gap by calling
+  `gh workflow run ci.yml --ref main` after the merge.
+  `workflow_dispatch` is **exempt** from the GITHUB_TOKEN filter,
+  so the dispatched CI run actually fires.
+
+### added
+
+- **`workflow_dispatch:` trigger added to `ci.yml`.** Required by
+  the rc.5 dispatch call above. Side benefit: operators can now
+  manually fire CI against any commit on main.
+- **CI run URL in the auto-update step summary.** The post-execution
+  report now lists the dispatched-CI run URL alongside the PR URL,
+  hash, and merge SHA — single-screen audit per cycle.
+
+### audited (no code change)
+
+- **Drift-detector inventory.** 12 detectors classified across the
+  codebase: 6 auto-implementing (framework upstream drift, security
+  threat-intel, bridge drift, template content, tool-scope at CI
+  time, watchdog auto-issue) and 6 correctly advisory because
+  mechanical auto-fix would be unsafe (shrink, orphan, dual-
+  descriptor, budget, prefix-cache, operational-JSON). Full
+  inventory in
+  `references/plans/rc5-drift-detector-inventory-2026-05-27.plan.md`.
+  No gaps requiring closure.
 
 ## [1.0.0-rc.4] - 2026-05-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentteams"
-version = "1.0.0rc4"
+version = "1.0.0rc5"
 description = "Generate a complete, coordinated AI agent team for any project from a single description file."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_auto_update_workflow.py
+++ b/tests/test_auto_update_workflow.py
@@ -97,6 +97,37 @@ def test_workflow_emits_post_execution_step_summary():
     assert 'gh pr diff' in text
 
 
+def test_workflow_dispatches_ci_after_automerge():
+    """rc.5: after the auto-merge lands the commit on main, the workflow
+    must dispatch ci.yml against main. workflow_dispatch is exempt from
+    the GITHUB_TOKEN filter, so this restores the post-merge safety net
+    that the rc.4 CHANGELOG claimed but did not actually deliver.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    # The dispatch must come AFTER the merge (substring order check).
+    merge_idx = text.find('gh pr merge "$pr_num" --merge --delete-branch')
+    dispatch_idx = text.find('gh workflow run ci.yml --ref main')
+    assert merge_idx >= 0, "merge step missing"
+    assert dispatch_idx >= 0, "ci.yml dispatch step missing"
+    assert dispatch_idx > merge_idx, (
+        "CI dispatch must run AFTER the merge so it tests the merge commit"
+    )
+
+
+def test_ci_workflow_accepts_dispatch():
+    """rc.5: ci.yml must declare workflow_dispatch so the framework-auto-update
+    workflow can fire it programmatically. Without this trigger the
+    dispatch in framework-auto-update is a no-op.
+    """
+    ci_path = WORKFLOW.parent / "ci.yml"
+    text = ci_path.read_text(encoding="utf-8")
+    import re as _re
+    on_block = _re.search(r"^on:\n((?:[ \t#].*\n)+)", text, _re.MULTILINE)
+    assert on_block, "ci.yml has no on: block"
+    assert _re.search(r"^\s*workflow_dispatch:\s*$", on_block.group(1), _re.MULTILINE), \
+        "ci.yml must include workflow_dispatch under on:"
+
+
 def test_workflow_targets_only_main_via_pr():
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "--base main" in text


### PR DESCRIPTION
## Summary

Two audited plans, one PR.

### rc.5 fix
rc.4 production test (PR #10) revealed that the rc.4 CHANGELOG's "post-merge CI is the safety net" claim was wrong: `GITHUB_TOKEN`-merge events suppress workflow runs. `gh api .../commits/25afe9f/check-runs` returned empty. rc.5 closes this by dispatching `ci.yml` explicitly after `gh pr merge` — `workflow_dispatch` is exempt from the filter. `ci.yml` gains `workflow_dispatch:` to enable the call.

### drift-detector inventory audit
12 detectors classified. 6 auto-implement (framework upstream, security threat-intel, bridge, template content, tool-scope at CI, watchdog auto-issue). 6 correctly advisory (shrink, orphan, dual-descriptor, budget, prefix-cache, operational-JSON — each unsafe to auto-fix mechanically). Full inventory + per-item rationale in [references/plans/rc5-drift-detector-inventory-2026-05-27.plan.md](references/plans/rc5-drift-detector-inventory-2026-05-27.plan.md).

## Test plan
- [x] 950 tests pass locally (memory-index 2-test flake is local-only — gitignored corpus differs from CI).
- [x] RSR1 clean.
- [x] Man-page current.
- [x] Both plans audited adversarial+conflict.
- [ ] CI green on this PR.
- [ ] Post-merge: tomorrow's scheduled auto-update (if drift) exercises the new dispatch path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)