### PR TITLE
feat(code-hygiene): CH-24 — exception handling is a last resort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   learned from the 2026-05-27 information-loss incident where
   `--bridge-refresh` clobbered user-authored `CLAUDE.md` and
   `.claude/*` content.
+- **Code-hygiene rule CH-24 — Exception Handling Is a Last Resort.**
+  New invariant extension rule (Defensive Programming, **Critical**) in
+  the `@code-hygiene` agent: `try`/`except`/`finally` is reserved for
+  genuinely unavoidable external failures (I/O, network, subprocess,
+  third-party calls). Expected conditions must instead be encoded in
+  dictionaries / lookup tables / explicit guards that **fail hard** on
+  the unexpected, so a broken program surfaces immediately rather than
+  being masked by broad exception handling — preserving the fast
+  iterative debug-and-test cycle. Reinforces CH-23 (Fail Fast on Invalid
+  Inputs). Added to `agentteams/templates/universal/code-hygiene.template.md`
+  (rule table, consult trigger, delegation row, mandatory-rule bullet),
+  the full enforcement section in
+  `agentteams/templates/domain/code-hygiene-rules-reference.template.md`
+  (preferred control-flow order, prohibited patterns, narrow-catch
+  requirements, illustrative `grep` check), and the Unix-philosophy
+  mapping (`unix-philosophy-mapping.template.md`, Tier 3 — Transparency +
+  Defensive Programming). Example `expected/` snapshots regenerated for
+  all four example teams.
 
 ### fixed
 

--- a/agentteams/templates/domain/code-hygiene-rules-reference.template.md
+++ b/agentteams/templates/domain/code-hygiene-rules-reference.template.md
@@ -127,6 +127,37 @@ All function and class inputs must be type-checked (statically, at runtime, or b
 
 Invalid inputs must raise explicit errors. Invalid data must never pass silently, and implicit fallback behavior that masks bad inputs is prohibited.
 
+### CH-24 — Exception Handling Is a Last Resort; Encode Conditions Explicitly
+
+**Category:** Defensive Programming
+**Severity:** Critical
+
+`try`/`except`/`finally` is the *last* resort, not the first. Broad or speculative exception handling hides the moment a program breaks, which delays the iterative debug-and-test cycle that depends on knowing immediately that something is wrong.
+
+**Preferred order of control flow:**
+
+1. **Encode expected conditions in data.** Map valid cases in a dictionary / lookup table / dispatch map. Membership and key lookups make the set of handled cases explicit and reviewable.
+2. **Guard with explicit checks, then fail hard.** Validate up front and `raise` (or assert) on the unexpected — see [[CH-23]]. A loud failure is a working failure: it points straight at the defect.
+3. **Use `try`/`except` only for genuinely unavoidable external failures** — I/O, network, subprocess, third-party calls whose failure modes cannot be predicted by inspection.
+
+**Prohibited patterns:**
+
+- Bare `except:` or `except Exception:` that swallows or logs-and-continues, hiding the real failure.
+- `try`/`except` used as flow control where a dictionary lookup, membership test, or `if`/`elif` chain would express the condition directly.
+- `except` blocks that return a default / fallback value, masking that the program is in a broken state.
+- `finally` used to paper over partial failures instead of letting the error propagate.
+
+**Required when `try`/`except` is genuinely warranted:**
+
+- Catch the *narrowest* applicable exception type, never a bare or blanket catch.
+- Either re-raise (optionally wrapped with context) or handle the specific, known recoverable case — never silently continue.
+
+**Enforcement check (illustrative):**
+```
+grep -rn "except:\|except Exception" {PRIMARY_OUTPUT_DIR}
+```
+Each hit must be justified as an unavoidable external-failure boundary; otherwise it is a violation. Prefer a dictionary-driven dispatch or an explicit guard that raises.
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/agentteams/templates/domain/unix-philosophy-mapping.template.md
+++ b/agentteams/templates/domain/unix-philosophy-mapping.template.md
@@ -2,7 +2,7 @@
 # Unix Philosophy — Code Hygiene Mapping ({PROJECT_NAME})
 
 > **Purpose:** Document how code-hygiene rules align with principles from Unix system design and software architecture
-> **Applies to:** CH-01 through CH-23 rule interpretations
+> **Applies to:** CH-01 through CH-24 rule interpretations
 > **Relationship:** This is a *reference for reasoning*, not the authoritative source of rules. See `code-hygiene-rules.reference.md` for the complete enforcement catalog.
 > **Authority Position:** Complements (not supersedes) the authority hierarchy defined in orchestrator.agent.md
 > **Maintenance:** Updated by `@agent-updater` when code-hygiene-rules.reference.md changes AND when interpretations of Unix principles need clarification
@@ -111,13 +111,14 @@ This principle insists on **discoverability and explicitness**. Hidden behaviors
 
 ## Extension Rules (CH-21+) and Design Principles
 
-The repository adds three critical enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
+The repository adds four enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
 
 | Rule | Tier | Principle Connection |
 |------|------|---------------------|
 | **CH-21** — Validate New Features Before Mainline Integration | 3 | **Defensive Programming.** Untested features create hidden states and unpredictable behaviors. Validation ensures the feature works before integration. (Project-specific mandate; not Unix-derived.) |
 | **CH-22** — Type Check Function/Class Inputs | 3 | **Type Safety.** Type checking makes input contracts explicit. Implicit type coercion hides expectations and causes subtle bugs. (Project-specific mandate; complements simplicity principles.) |
 | **CH-23** — Fail Fast on Invalid Inputs | 3 | **Defensive Programming.** Explicit errors reveal problems early. Silent failures hide bugs deep in a system, making them expensive to diagnose. (Project-specific mandate; aligns with transparency but not Unix-specific.) |
+| **CH-24** — Exception Handling Is a Last Resort; Encode Conditions Explicitly | 3 | **Transparency + Defensive Programming.** Encoding cases in dictionaries and failing hard keeps the program's true state visible; broad `try`/`except` hides brokenness and defeats fast iterative debugging. Aligns with "Value Transparency and Clarity" — behavior must be discoverable, not buried under blanket error suppression. (Project-specific mandate; reinforces [[CH-23]].) |
 
 ---
 
@@ -130,7 +131,7 @@ Understanding the alignment between rules and design principles helps developers
 3. **Extend the rule set** — New rules should be grounded in principles or clearly justified as project-specific
 4. **Maintain over time** — Knowing *why* a rule exists makes it easier to keep it in sync as the project evolves
 
-**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-23) that serve operational needs independent of Unix philosophy.
+**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-24) that serve operational needs independent of Unix philosophy.
 
 ---
 

--- a/agentteams/templates/universal/code-hygiene.template.md
+++ b/agentteams/templates/universal/code-hygiene.template.md
@@ -58,6 +58,7 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New executable/script file added | CH-02 (lifecycle tagging) | — |
 | New file added to `{PRIMARY_OUTPUT_DIR}` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
+| New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
 | Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
@@ -105,6 +106,7 @@ Required project extensions for this repository:
 | CH-21 | Validate New Features Before Mainline Integration | Testing | High |
 | CH-22 | Type Check Function/Class Inputs | Type Safety | High |
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
+| CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 
 ### Audit Output Format
 
@@ -133,6 +135,7 @@ Overall: 18/20 checks passing
 | Agent doc contradictions (CH-20) | `@conflict-auditor` → `@agent-refactor` |
 | Config values hardcoded in source (CH-09) | Report only; correction by `@primary-producer` |
 | Dead code (CH-10), circular imports (CH-13) | Report only; correction by `@primary-producer` |
+| Silent fallbacks / over-broad exception handling (CH-23, CH-24) | Report only; correction by `@primary-producer` |
 
 ---
 
@@ -146,3 +149,4 @@ Overall: 18/20 checks passing
 - **CH-21 is mandatory in this repository.** New features must be tested/validated before integration into the main program.
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
+- **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.

--- a/docs_src/api-reference/feature-inventory.md
+++ b/docs_src/api-reference/feature-inventory.md
@@ -165,7 +165,7 @@ The following eleven agents are included in every generated team, regardless of 
 
 76. **`@navigator`** — Project structure mapping, file location queries, dependency tracking (read-only)
 77. **`@security`** — Highest-priority sentinel; clears destructive operations, credential exposure, and external writes (read-only)
-78. **`@code-hygiene`** — Architecture auditor; file hygiene, duplication, script lifecycle, agent doc quality — CH-01 through CH-20+ (read-only)
+78. **`@code-hygiene`** — Architecture auditor; file hygiene, duplication, script lifecycle, agent doc quality — invariant CH-01 through CH-20 plus project extension rules CH-21–CH-24 (Testing, Type Safety, Defensive Programming; CH-24: `try`/`except`/`finally` is a last resort — encode expected conditions in dictionaries/guards and fail hard, reinforcing CH-23 Fail Fast) (read-only)
 79. **`@adversarial`** — Presupposition critic; challenges plans and hidden assumptions before execution (read-only)
 80. **`@conflict-auditor`** — Detects logical inconsistencies across all output files; logs findings (read + log)
 81. **`@conflict-resolution`** — Makes ACCEPT/REJECT/REVISE decisions on flagged conflicts (read + edit)
@@ -188,81 +188,81 @@ Workflows are step sequences embedded in the generated Orchestrator agent. Every
 91. **Workflow 5 — Consistency Review** — `@adversarial` challenge → cross-file consistency audit → technical validation → `@agent-updater`
 92. **Workflow 6 — Documentation Maintenance** — Sync agent docs → refactor check → consistency audit
 93. **Workflow 7 — Cleanup** — Identify stale artifacts → `@adversarial` review → `@security` clearance → delete → update docs
-94. **Workflow 8 — Code Hygiene Audit** — CH-01–CH-20 audit → `@adversarial` guard before deletion plan → conditional cleanup/refactor
+94. **Workflow 8 — Code Hygiene Audit** — CH-01–CH-24 audit (CH-01–CH-20 invariant + CH-21–CH-24 project extensions) → `@adversarial` guard before deletion plan → conditional cleanup/refactor
 95. **Workflow 9 — Cross-Repository Coordination** — Impact assessment → approved updates → adjacent-repo writes (security-cleared) → consistency audit
 96. **Workflow 10 — Plan Documentation & Review** — Plan status scan → pre-execution truth check via `@technical-validator` → surface blocked steps
 97. **Workflow 10B — Work Summary Reporting** — Generate daily/weekly/monthly summaries from plan artifacts and git history, then audit them
-99. **Workflow 10C — Post-Production Audit Verification (Optional)** — User-editable extension workflow for outcome verification after implementation claims; runs `@post-production-auditor` + adversarial/conflict checks; blocks closeout on `FAIL`/`INCONCLUSIVE`
-98. **Workflow 11 — Final Check (Part A)** — Scan current plan's `steps.csv` for `pending`/`blocked` rows; create audited sub-plans for each
-98. **Workflow 11 — Final Check (Part B)** — Scan `CHANGELOG.md` Known Issues, `tmp/by-week/YYYY-Www/` plan CSVs (legacy: `tmp/` root), and `git status` for at-large open issues; subject summaries to `@adversarial` + `@conflict-auditor`
+98. **Workflow 10C — Post-Production Audit Verification (Optional)** — User-editable extension workflow for outcome verification after implementation claims; runs `@post-production-auditor` + adversarial/conflict checks; blocks closeout on `FAIL`/`INCONCLUSIVE`
+99. **Workflow 11 — Final Check (Part A)** — Scan current plan's `steps.csv` for `pending`/`blocked` rows; create audited sub-plans for each
+100. **Workflow 11 — Final Check (Part B)** — Scan `CHANGELOG.md` Known Issues, `tmp/by-week/YYYY-Www/` plan CSVs (legacy: `tmp/` root), and `git status` for at-large open issues; subject summaries to `@adversarial` + `@conflict-auditor`
 
 ---
 
 ## Governance Infrastructure
 
-100. **Constitutional Rules** — Immutable rules encoded in the Orchestrator template: security clearance gates, code-hygiene before merge, conflict audit after multi-file sessions, adversarial review before irreversible changes
-101. **Authority Hierarchy** — Explicit precedence ordering encoded in every generated Orchestrator (template library → schemas → pipeline source → placeholder conventions → implementation plan)
-102. **Automatic `@agent-updater` Routing in Documentation-Impact Workflows** — Routed in Workflows 1, 2, 3, 5, 6, 7, 8, and 9 when knowledge-mutating or coordination changes occur
-103. **`@adversarial` Guards in Audit Workflows** — `@adversarial` runs as step 1 of Workflow 5 and step 2 of Workflow 8 to prevent stale-assumption conclusions
-104. **Pre-Execution Truth Check** — `@technical-validator` must verify factual claims in each plan step before it is marked `in_progress`
-105. **Drift-as-Trigger** — An explicit trigger in `@agent-updater` trigger tables: drift detected by `--check` requires re-render and re-verify before the next workflow
-106. **Initialization-as-Trigger** — First successful team generation is an explicit lifecycle trigger: it establishes the baseline inventory and trigger corpus used by future update and drift logic
-107. **Update Lifecycle Trigger Contract** — Canonical `--update --merge` runs must reconcile drift, emit newly required files, preserve manual values, and preserve user-authored content outside fenced regions
-108. **Missing Expected Output Recovery Trigger** — During update, absent expected standard outputs are treated as drift and must be restored even if template hashes are unchanged
-109. **Cross-Repository Security Rule** — Any write outside this project's configured primary output directory must be assessed by `@repo-liaison` and cleared by `@security`
-110. **User-Editable Gap Safety Pattern** — Optional routing rows and optional workflow extensions (such as 10C) must be added outside FENCED sections so `--update --merge` does not force-propagate them to teams that do not include the required agent
-111. **Post-Production Closure Gate Artifacts** — Optional post-production audits can emit `closure_gate_status.json`, `capability_check.json`, and `decision_replay_packet.json` to support fail-closed closeout decisions and replay-auditability
+101. **Constitutional Rules** — Immutable rules encoded in the Orchestrator template: security clearance gates, code-hygiene before merge, conflict audit after multi-file sessions, adversarial review before irreversible changes
+102. **Authority Hierarchy** — Explicit precedence ordering encoded in every generated Orchestrator (template library → schemas → pipeline source → placeholder conventions → implementation plan)
+103. **Automatic `@agent-updater` Routing in Documentation-Impact Workflows** — Routed in Workflows 1, 2, 3, 5, 6, 7, 8, and 9 when knowledge-mutating or coordination changes occur
+104. **`@adversarial` Guards in Audit Workflows** — `@adversarial` runs as step 1 of Workflow 5 and step 2 of Workflow 8 to prevent stale-assumption conclusions
+105. **Pre-Execution Truth Check** — `@technical-validator` must verify factual claims in each plan step before it is marked `in_progress`
+106. **Drift-as-Trigger** — An explicit trigger in `@agent-updater` trigger tables: drift detected by `--check` requires re-render and re-verify before the next workflow
+107. **Initialization-as-Trigger** — First successful team generation is an explicit lifecycle trigger: it establishes the baseline inventory and trigger corpus used by future update and drift logic
+108. **Update Lifecycle Trigger Contract** — Canonical `--update --merge` runs must reconcile drift, emit newly required files, preserve manual values, and preserve user-authored content outside fenced regions
+109. **Missing Expected Output Recovery Trigger** — During update, absent expected standard outputs are treated as drift and must be restored even if template hashes are unchanged
+110. **Cross-Repository Security Rule** — Any write outside this project's configured primary output directory must be assessed by `@repo-liaison` and cleared by `@security`
+111. **User-Editable Gap Safety Pattern** — Optional routing rows and optional workflow extensions (such as 10C) must be added outside FENCED sections so `--update --merge` does not force-propagate them to teams that do not include the required agent
+112. **Post-Production Closure Gate Artifacts** — Optional post-production audits can emit `closure_gate_status.json`, `capability_check.json`, and `decision_replay_packet.json` to support fail-closed closeout decisions and replay-auditability
 
 ---
 
 ## Interoperability
 
-107. **`convert` Module** — Direct format migration between framework outputs (`copilot-vscode` ↔ `copilot-cli` ↔ `claude`)
-108. **`--convert-from` Flag** — Convert an existing agent team to a different framework format
-109. **File Classification** — Auto-detect file role (agent, instruction, reference) for correct translation
-110. **`interop` Module** — Canonical Agent Interface (CAI) normalization and compatibility pipeline
-111. **`--interop-from` Flag** — Run the CAI interop pipeline against an existing team
-112. **`bridge` Module** — Lightweight runtime compatibility bridge; generate bridge artifacts without regenerating sources
-113. **`--bridge-from` Flag** — Generate bridge artifacts from a source canonical team
-114. **Runtime Handoff Manifest** — `references/runtime-handoffs.json`; emitted when handoffs are extracted from non-VS Code adapters, consumed by bridge layers and external tooling
+113. **`convert` Module** — Direct format migration between framework outputs (`copilot-vscode` ↔ `copilot-cli` ↔ `claude`)
+114. **`--convert-from` Flag** — Convert an existing agent team to a different framework format
+115. **File Classification** — Auto-detect file role (agent, instruction, reference) for correct translation
+116. **`interop` Module** — Canonical Agent Interface (CAI) normalization and compatibility pipeline
+117. **`--interop-from` Flag** — Run the CAI interop pipeline against an existing team
+118. **`bridge` Module** — Lightweight runtime compatibility bridge; generate bridge artifacts without regenerating sources
+119. **`--bridge-from` Flag** — Generate bridge artifacts from a source canonical team
+120. **Runtime Handoff Manifest** — `references/runtime-handoffs.json`; emitted when handoffs are extracted from non-VS Code adapters, consumed by bridge layers and external tooling
 
 ---
 
 ## Bridge Automation
 
-115. **`run_daily_bridge_maintenance.sh`** — Daily bridge refresh/check script that halts the run when the security-maintenance preflight fails and continues with warnings only for non-critical bridge refresh/check subtasks
-116. **`bridge-maintenance.yml` CI Workflow** — GitHub Actions workflow for daily automated bridge maintenance
-117. **`bridge-watchdog.yml` CI Workflow** — Staleness monitoring; creates deduplicated GitHub issues when drift is detected
-118. **Bridge Staleness Detection** — Compare bridge artifacts against source team; surface divergence
-119. **Deduplicated Issue Creation** — Watchdog suppresses duplicate GitHub issues for the same staleness event
-120. **CI Fallback Mechanism** — Bridge refresh/check subtasks continue with warnings, but security-maintenance preflight failures abort the workflow
-121. **Snapshot Archive** — Pre-update snapshots stored in `references/plans/snapshots-*/` for reversible rollback
+121. **`run_daily_bridge_maintenance.sh`** — Daily bridge refresh/check script that halts the run when the security-maintenance preflight fails and continues with warnings only for non-critical bridge refresh/check subtasks
+122. **`bridge-maintenance.yml` CI Workflow** — GitHub Actions workflow for daily automated bridge maintenance
+123. **`bridge-watchdog.yml` CI Workflow** — Staleness monitoring; creates deduplicated GitHub issues when drift is detected
+124. **Bridge Staleness Detection** — Compare bridge artifacts against source team; surface divergence
+125. **Deduplicated Issue Creation** — Watchdog suppresses duplicate GitHub issues for the same staleness event
+126. **CI Fallback Mechanism** — Bridge refresh/check subtasks continue with warnings, but security-maintenance preflight failures abort the workflow
+127. **Snapshot Archive** — Pre-update snapshots stored in `references/plans/snapshots-*/` for reversible rollback
 
 ---
 
 ## Cross-Repository Support
 
-122. **`@repo-liaison` Agent** — Manages cross-repository impact assessment, updates, and orchestrator coordination
-123. **`references/adjacent-repos.md`** — Living record of adjacent repositories with changelog entries
-124. **Protocol 1 — Impact Assessment** — Evaluate which adjacent repos are affected by a proposed change; produce an Impact Report
-125. **Protocol 2 — Adjacent Updates** — Apply approved updates to neighboring project repos (requires `@security` clearance on each write)
-126. **Protocol 3 — Orchestrator Coordination** — Formal coordination request between independent orchestrators managing different repositories
-127. **`@repo-liaison` in Constitutional Rules** — Any write outside `src/` must be assessed by `@repo-liaison` before `@security` clearance can be granted
-128. **`orchestrator-workflows.reference.md`** — Reference guide documenting the baseline workflow set plus optional extension workflows (for example 10C when configured); kept in sync by `@agent-updater`
+128. **`@repo-liaison` Agent** — Manages cross-repository impact assessment, updates, and orchestrator coordination
+129. **`references/adjacent-repos.md`** — Living record of adjacent repositories with changelog entries
+130. **Protocol 1 — Impact Assessment** — Evaluate which adjacent repos are affected by a proposed change; produce an Impact Report
+131. **Protocol 2 — Adjacent Updates** — Apply approved updates to neighboring project repos (requires `@security` clearance on each write)
+132. **Protocol 3 — Orchestrator Coordination** — Formal coordination request between independent orchestrators managing different repositories
+133. **`@repo-liaison` in Constitutional Rules** — Any write outside `src/` must be assessed by `@repo-liaison` before `@security` clearance can be granted
+134. **`orchestrator-workflows.reference.md`** — Reference guide documenting the baseline workflow set plus optional extension workflows (for example 10C when configured); kept in sync by `@agent-updater`
 
 ---
 
 ## Drift Trust & Delivery Gating
 
-129. **`FINGERPRINT_ALGO_VERSION` Constant** — Module-level integer in `agentteams.drift` recording the version of the manifest-fingerprint algorithm; recorded into `build-log.json` on every write and consulted on `--check` / `--update` to migrate existing teams when fingerprint semantics change
-130. **Algo-Bump Migration Mechanism** — `compute_structural_diff` detects `fingerprint_algo_version` mismatch between the stored build-log and the current module value, sets `manifest_changed`, and promotes affected files with `_reason = "fingerprint algo version bumped"` for a one-shot re-evaluation; legacy logs missing the field do not trigger promotion on their own
-131. **Observable Baseline Self-Heal on `--update`** — When an `--update` run finds no material drift but the recorded fingerprint or algo version is stale, the build-log baseline is refreshed and the run prints `✓  Healed build-log baseline (no material drift; fingerprint refreshed).`; heal occurs before delivery-receipt attestation
-132. **`refine_manifest_promotion` Render-Faithful Reconciliation** — Pure public function in `agentteams.drift` that demotes fingerprint-only promotions whose rendered content matches disk byte-for-byte; caller supplies a `content_matches(path)` closure; preserves `manifest_changed` as telemetry
-133. **`--check` Option C Render-Faithful Mode** — When the structural diff sets `manifest_changed` with a manifest-promotion reason, `--check` runs the full render pipeline (`render.render_all` → framework adapter → handoff/graph append) and applies `refine_manifest_promotion` against a content-match closure mirroring `--update`'s, eliminating false-positive drift signals
-134. **`--check` / `--update --dry-run` Parity Contract** — `--check` and `--update --dry-run` report the same `has_changes` set for the same inputs; enforced by `tests/test_integration.py::test_check_parity_with_update_dry_run`
-135. **Delivery Receipt Artifact** — `references/delivery-receipt.json` written after every successful `--update` (non-dry-run) recording `artifact_type`, `receipt_schema_version`, `delivered_at`, `project_name`, `framework`, `manifest_fingerprint`, and `fingerprint_algo_version`; heal-first-attest-second order ensures the receipt records the post-heal state; write failures warn on stderr but do not fail the run; receipt file is excluded from drift detection
-136. **`schemas/delivery-receipt.schema.json`** — Draft-07 JSON Schema for the delivery receipt; `additionalProperties: false`; top-level discriminator is `artifact_type` (const `"delivery-receipt"`); `receipt_schema_version` const `"1.0"`
-137. **`docs_src/delivery-procedure.md` Operator Guide** — Documents the heal/attest order, receipt schema, and operator procedure for verifying a delivered update; registered under Guides in `mkdocs.yml`
+135. **`FINGERPRINT_ALGO_VERSION` Constant** — Module-level integer in `agentteams.drift` recording the version of the manifest-fingerprint algorithm; recorded into `build-log.json` on every write and consulted on `--check` / `--update` to migrate existing teams when fingerprint semantics change
+136. **Algo-Bump Migration Mechanism** — `compute_structural_diff` detects `fingerprint_algo_version` mismatch between the stored build-log and the current module value, sets `manifest_changed`, and promotes affected files with `_reason = "fingerprint algo version bumped"` for a one-shot re-evaluation; legacy logs missing the field do not trigger promotion on their own
+137. **Observable Baseline Self-Heal on `--update`** — When an `--update` run finds no material drift but the recorded fingerprint or algo version is stale, the build-log baseline is refreshed and the run prints `✓  Healed build-log baseline (no material drift; fingerprint refreshed).`; heal occurs before delivery-receipt attestation
+138. **`refine_manifest_promotion` Render-Faithful Reconciliation** — Pure public function in `agentteams.drift` that demotes fingerprint-only promotions whose rendered content matches disk byte-for-byte; caller supplies a `content_matches(path)` closure; preserves `manifest_changed` as telemetry
+139. **`--check` Option C Render-Faithful Mode** — When the structural diff sets `manifest_changed` with a manifest-promotion reason, `--check` runs the full render pipeline (`render.render_all` → framework adapter → handoff/graph append) and applies `refine_manifest_promotion` against a content-match closure mirroring `--update`'s, eliminating false-positive drift signals
+140. **`--check` / `--update --dry-run` Parity Contract** — `--check` and `--update --dry-run` report the same `has_changes` set for the same inputs; enforced by `tests/test_integration.py::test_check_parity_with_update_dry_run`
+141. **Delivery Receipt Artifact** — `references/delivery-receipt.json` written after every successful `--update` (non-dry-run) recording `artifact_type`, `receipt_schema_version`, `delivered_at`, `project_name`, `framework`, `manifest_fingerprint`, and `fingerprint_algo_version`; heal-first-attest-second order ensures the receipt records the post-heal state; write failures warn on stderr but do not fail the run; receipt file is excluded from drift detection
+142. **`schemas/delivery-receipt.schema.json`** — Draft-07 JSON Schema for the delivery receipt; `additionalProperties: false`; top-level discriminator is `artifact_type` (const `"delivery-receipt"`); `receipt_schema_version` const `"1.0"`
+143. **`docs_src/delivery-procedure.md` Operator Guide** — Documents the heal/attest order, receipt schema, and operator procedure for verifying a delivered update; registered under Guides in `mkdocs.yml`
 
 ---
 

--- a/examples/data-pipeline/expected/code-hygiene.agent.md
+++ b/examples/data-pipeline/expected/code-hygiene.agent.md
@@ -59,6 +59,7 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New executable/script file added | CH-02 (lifecycle tagging) | — |
 | New file added to `src/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
+| New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
 | Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
@@ -106,6 +107,7 @@ Required project extensions for this repository:
 | CH-21 | Validate New Features Before Mainline Integration | Testing | High |
 | CH-22 | Type Check Function/Class Inputs | Type Safety | High |
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
+| CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 
 ### Audit Output Format
 
@@ -134,6 +136,7 @@ Overall: 18/20 checks passing
 | Agent doc contradictions (CH-20) | `@conflict-auditor` → `@agent-refactor` |
 | Config values hardcoded in source (CH-09) | Report only; correction by `@primary-producer` |
 | Dead code (CH-10), circular imports (CH-13) | Report only; correction by `@primary-producer` |
+| Silent fallbacks / over-broad exception handling (CH-23, CH-24) | Report only; correction by `@primary-producer` |
 
 ---
 
@@ -147,6 +150,7 @@ Overall: 18/20 checks passing
 - **CH-21 is mandatory in this repository.** New features must be tested/validated before integration into the main program.
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
+- **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/data-pipeline/expected/references/code-hygiene-rules.reference.md
+++ b/examples/data-pipeline/expected/references/code-hygiene-rules.reference.md
@@ -128,6 +128,37 @@ All function and class inputs must be type-checked (statically, at runtime, or b
 
 Invalid inputs must raise explicit errors. Invalid data must never pass silently, and implicit fallback behavior that masks bad inputs is prohibited.
 
+### CH-24 — Exception Handling Is a Last Resort; Encode Conditions Explicitly
+
+**Category:** Defensive Programming
+**Severity:** Critical
+
+`try`/`except`/`finally` is the *last* resort, not the first. Broad or speculative exception handling hides the moment a program breaks, which delays the iterative debug-and-test cycle that depends on knowing immediately that something is wrong.
+
+**Preferred order of control flow:**
+
+1. **Encode expected conditions in data.** Map valid cases in a dictionary / lookup table / dispatch map. Membership and key lookups make the set of handled cases explicit and reviewable.
+2. **Guard with explicit checks, then fail hard.** Validate up front and `raise` (or assert) on the unexpected — see [[CH-23]]. A loud failure is a working failure: it points straight at the defect.
+3. **Use `try`/`except` only for genuinely unavoidable external failures** — I/O, network, subprocess, third-party calls whose failure modes cannot be predicted by inspection.
+
+**Prohibited patterns:**
+
+- Bare `except:` or `except Exception:` that swallows or logs-and-continues, hiding the real failure.
+- `try`/`except` used as flow control where a dictionary lookup, membership test, or `if`/`elif` chain would express the condition directly.
+- `except` blocks that return a default / fallback value, masking that the program is in a broken state.
+- `finally` used to paper over partial failures instead of letting the error propagate.
+
+**Required when `try`/`except` is genuinely warranted:**
+
+- Catch the *narrowest* applicable exception type, never a bare or blanket catch.
+- Either re-raise (optionally wrapped with context) or handle the specific, known recoverable case — never silently continue.
+
+**Enforcement check (illustrative):**
+```
+grep -rn "except:\|except Exception" src/
+```
+Each hit must be justified as an unavoidable external-failure boundary; otherwise it is a violation. Prefer a dictionary-driven dispatch or an explicit guard that raises.
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/examples/project-repositories/expected/code-hygiene.agent.md
+++ b/examples/project-repositories/expected/code-hygiene.agent.md
@@ -26,6 +26,7 @@ handoffs:
     prompt: "Code hygiene review is complete. Returning findings to the orchestrator."
     send: false
 ---
+<!-- AGENTTEAMS:BEGIN content v=1 -->
 
 # Code Hygiene — ProjectRepositories
 
@@ -58,6 +59,7 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New executable/script file added | CH-02 (lifecycle tagging) | — |
 | New file added to `*/outputs/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
+| New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
 | Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
@@ -105,6 +107,7 @@ Required project extensions for this repository:
 | CH-21 | Validate New Features Before Mainline Integration | Testing | High |
 | CH-22 | Type Check Function/Class Inputs | Type Safety | High |
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
+| CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 
 ### Audit Output Format
 
@@ -133,6 +136,7 @@ Overall: 18/20 checks passing
 | Agent doc contradictions (CH-20) | `@conflict-auditor` → `@agent-refactor` |
 | Config values hardcoded in source (CH-09) | Report only; correction by `@primary-producer` |
 | Dead code (CH-10), circular imports (CH-13) | Report only; correction by `@primary-producer` |
+| Silent fallbacks / over-broad exception handling (CH-23, CH-24) | Report only; correction by `@primary-producer` |
 
 ---
 
@@ -146,3 +150,9 @@ Overall: 18/20 checks passing
 - **CH-21 is mandatory in this repository.** New features must be tested/validated before integration into the main program.
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
+- **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
+<!-- AGENTTEAMS:END content -->
+
+## Project-Specific Notes
+
+> ⚙️ **USER-EDITABLE** — project-specific rules, overrides, and extensions for this agent. This section lies outside every `AGENTTEAMS` fence and is preserved verbatim across `agentteams --update --merge`.

--- a/examples/project-repositories/expected/references/code-hygiene-rules.reference.md
+++ b/examples/project-repositories/expected/references/code-hygiene-rules.reference.md
@@ -1,3 +1,4 @@
+<!-- AGENTTEAMS:BEGIN content v=1 -->
 # Code Hygiene Rules — Enforcement Catalog (ProjectRepositories)
 
 > **Authoritative source for:** `@code-hygiene` agent rule enforcement
@@ -127,6 +128,37 @@ All function and class inputs must be type-checked (statically, at runtime, or b
 
 Invalid inputs must raise explicit errors. Invalid data must never pass silently, and implicit fallback behavior that masks bad inputs is prohibited.
 
+### CH-24 — Exception Handling Is a Last Resort; Encode Conditions Explicitly
+
+**Category:** Defensive Programming
+**Severity:** Critical
+
+`try`/`except`/`finally` is the *last* resort, not the first. Broad or speculative exception handling hides the moment a program breaks, which delays the iterative debug-and-test cycle that depends on knowing immediately that something is wrong.
+
+**Preferred order of control flow:**
+
+1. **Encode expected conditions in data.** Map valid cases in a dictionary / lookup table / dispatch map. Membership and key lookups make the set of handled cases explicit and reviewable.
+2. **Guard with explicit checks, then fail hard.** Validate up front and `raise` (or assert) on the unexpected — see [[CH-23]]. A loud failure is a working failure: it points straight at the defect.
+3. **Use `try`/`except` only for genuinely unavoidable external failures** — I/O, network, subprocess, third-party calls whose failure modes cannot be predicted by inspection.
+
+**Prohibited patterns:**
+
+- Bare `except:` or `except Exception:` that swallows or logs-and-continues, hiding the real failure.
+- `try`/`except` used as flow control where a dictionary lookup, membership test, or `if`/`elif` chain would express the condition directly.
+- `except` blocks that return a default / fallback value, masking that the program is in a broken state.
+- `finally` used to paper over partial failures instead of letting the error propagate.
+
+**Required when `try`/`except` is genuinely warranted:**
+
+- Catch the *narrowest* applicable exception type, never a bare or blanket catch.
+- Either re-raise (optionally wrapped with context) or handle the specific, known recoverable case — never silently continue.
+
+**Enforcement check (illustrative):**
+```
+grep -rn "except:\|except Exception" */outputs/
+```
+Each hit must be justified as an unavoidable external-failure boundary; otherwise it is a violation. Prefer a dictionary-driven dispatch or an explicit guard that raises.
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 
@@ -135,3 +167,4 @@ Invalid inputs must raise explicit errors. Invalid data must never pass silently
 
 Description and enforcement check.
 -->
+<!-- AGENTTEAMS:END content -->

--- a/examples/research-project/expected/code-hygiene.agent.md
+++ b/examples/research-project/expected/code-hygiene.agent.md
@@ -59,6 +59,7 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New executable/script file added | CH-02 (lifecycle tagging) | — |
 | New file added to `html/chapters/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
+| New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
 | Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
@@ -106,6 +107,7 @@ Required project extensions for this repository:
 | CH-21 | Validate New Features Before Mainline Integration | Testing | High |
 | CH-22 | Type Check Function/Class Inputs | Type Safety | High |
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
+| CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 
 ### Audit Output Format
 
@@ -134,6 +136,7 @@ Overall: 18/20 checks passing
 | Agent doc contradictions (CH-20) | `@conflict-auditor` → `@agent-refactor` |
 | Config values hardcoded in source (CH-09) | Report only; correction by `@primary-producer` |
 | Dead code (CH-10), circular imports (CH-13) | Report only; correction by `@primary-producer` |
+| Silent fallbacks / over-broad exception handling (CH-23, CH-24) | Report only; correction by `@primary-producer` |
 
 ---
 
@@ -147,6 +150,7 @@ Overall: 18/20 checks passing
 - **CH-21 is mandatory in this repository.** New features must be tested/validated before integration into the main program.
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
+- **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/research-project/expected/references/code-hygiene-rules.reference.md
+++ b/examples/research-project/expected/references/code-hygiene-rules.reference.md
@@ -128,6 +128,37 @@ All function and class inputs must be type-checked (statically, at runtime, or b
 
 Invalid inputs must raise explicit errors. Invalid data must never pass silently, and implicit fallback behavior that masks bad inputs is prohibited.
 
+### CH-24 — Exception Handling Is a Last Resort; Encode Conditions Explicitly
+
+**Category:** Defensive Programming
+**Severity:** Critical
+
+`try`/`except`/`finally` is the *last* resort, not the first. Broad or speculative exception handling hides the moment a program breaks, which delays the iterative debug-and-test cycle that depends on knowing immediately that something is wrong.
+
+**Preferred order of control flow:**
+
+1. **Encode expected conditions in data.** Map valid cases in a dictionary / lookup table / dispatch map. Membership and key lookups make the set of handled cases explicit and reviewable.
+2. **Guard with explicit checks, then fail hard.** Validate up front and `raise` (or assert) on the unexpected — see [[CH-23]]. A loud failure is a working failure: it points straight at the defect.
+3. **Use `try`/`except` only for genuinely unavoidable external failures** — I/O, network, subprocess, third-party calls whose failure modes cannot be predicted by inspection.
+
+**Prohibited patterns:**
+
+- Bare `except:` or `except Exception:` that swallows or logs-and-continues, hiding the real failure.
+- `try`/`except` used as flow control where a dictionary lookup, membership test, or `if`/`elif` chain would express the condition directly.
+- `except` blocks that return a default / fallback value, masking that the program is in a broken state.
+- `finally` used to paper over partial failures instead of letting the error propagate.
+
+**Required when `try`/`except` is genuinely warranted:**
+
+- Catch the *narrowest* applicable exception type, never a bare or blanket catch.
+- Either re-raise (optionally wrapped with context) or handle the specific, known recoverable case — never silently continue.
+
+**Enforcement check (illustrative):**
+```
+grep -rn "except:\|except Exception" html/chapters/
+```
+Each hit must be justified as an unavoidable external-failure boundary; otherwise it is a violation. Prefer a dictionary-driven dispatch or an explicit guard that raises.
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/examples/software-project/expected/code-hygiene.agent.md
+++ b/examples/software-project/expected/code-hygiene.agent.md
@@ -59,6 +59,7 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New executable/script file added | CH-02 (lifecycle tagging) | — |
 | New file added to `src/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
+| New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
 | Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
@@ -106,6 +107,7 @@ Required project extensions for this repository:
 | CH-21 | Validate New Features Before Mainline Integration | Testing | High |
 | CH-22 | Type Check Function/Class Inputs | Type Safety | High |
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
+| CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 
 ### Audit Output Format
 
@@ -134,6 +136,7 @@ Overall: 18/20 checks passing
 | Agent doc contradictions (CH-20) | `@conflict-auditor` → `@agent-refactor` |
 | Config values hardcoded in source (CH-09) | Report only; correction by `@primary-producer` |
 | Dead code (CH-10), circular imports (CH-13) | Report only; correction by `@primary-producer` |
+| Silent fallbacks / over-broad exception handling (CH-23, CH-24) | Report only; correction by `@primary-producer` |
 
 ---
 
@@ -147,6 +150,7 @@ Overall: 18/20 checks passing
 - **CH-21 is mandatory in this repository.** New features must be tested/validated before integration into the main program.
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
+- **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/software-project/expected/references/code-hygiene-rules.reference.md
+++ b/examples/software-project/expected/references/code-hygiene-rules.reference.md
@@ -128,6 +128,37 @@ All function and class inputs must be type-checked (statically, at runtime, or b
 
 Invalid inputs must raise explicit errors. Invalid data must never pass silently, and implicit fallback behavior that masks bad inputs is prohibited.
 
+### CH-24 — Exception Handling Is a Last Resort; Encode Conditions Explicitly
+
+**Category:** Defensive Programming
+**Severity:** Critical
+
+`try`/`except`/`finally` is the *last* resort, not the first. Broad or speculative exception handling hides the moment a program breaks, which delays the iterative debug-and-test cycle that depends on knowing immediately that something is wrong.
+
+**Preferred order of control flow:**
+
+1. **Encode expected conditions in data.** Map valid cases in a dictionary / lookup table / dispatch map. Membership and key lookups make the set of handled cases explicit and reviewable.
+2. **Guard with explicit checks, then fail hard.** Validate up front and `raise` (or assert) on the unexpected — see [[CH-23]]. A loud failure is a working failure: it points straight at the defect.
+3. **Use `try`/`except` only for genuinely unavoidable external failures** — I/O, network, subprocess, third-party calls whose failure modes cannot be predicted by inspection.
+
+**Prohibited patterns:**
+
+- Bare `except:` or `except Exception:` that swallows or logs-and-continues, hiding the real failure.
+- `try`/`except` used as flow control where a dictionary lookup, membership test, or `if`/`elif` chain would express the condition directly.
+- `except` blocks that return a default / fallback value, masking that the program is in a broken state.
+- `finally` used to paper over partial failures instead of letting the error propagate.
+
+**Required when `try`/`except` is genuinely warranted:**
+
+- Catch the *narrowest* applicable exception type, never a bare or blanket catch.
+- Either re-raise (optionally wrapped with context) or handle the specific, known recoverable case — never silently continue.
+
+**Enforcement check (illustrative):**
+```
+grep -rn "except:\|except Exception" src/
+```
+Each hit must be justified as an unavoidable external-failure boundary; otherwise it is a violation. Prefer a dictionary-driven dispatch or an explicit guard that raises.
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 


### PR DESCRIPTION
## Summary

Adds code-hygiene rule **CH-24 — Exception Handling Is a Last Resort** and propagates it through templates, example snapshots, the changelog, and the API documentation.

`try`/`except`/`finally` is reserved for genuinely unavoidable external failures (I/O, network, subprocess, third-party calls). Expected conditions must instead be encoded in dictionaries / lookup tables / explicit guards that **fail hard** on the unexpected, so a broken program surfaces immediately rather than being masked by broad exception handling. Reinforces CH-23 (Fail Fast).

## Changes

**`feat` — rule (commit 1)**
- `universal/code-hygiene.template.md`: rule-table row, consult trigger, delegation row, mandatory-rule bullet
- `domain/code-hygiene-rules-reference.template.md`: full enforcement section (preferred control-flow order, prohibited patterns, narrow-catch requirements, illustrative grep check)
- `domain/unix-philosophy-mapping.template.md`: CH-24 mapped Tier 3 (Transparency + Defensive Programming); range extended to CH-01..CH-24
- regenerated `expected/` snapshots for all four example teams
- CHANGELOG `[Unreleased]` entry

**`docs` — feature inventory (commit 2)**, after passing the doc through adversarial + conflict audits:
- `@code-hygiene` / Workflow 8 entries reflect CH-21..CH-24 with **corrected category labels** (CH-21 Testing, CH-22 Type Safety, CH-23/24 Defensive Programming)
- **conflict fix:** the global numbered list had duplicate item numbers (`98`; `107-111` collided between Governance Infrastructure and Interoperability) and an out-of-order Workflows tail (`97→99→98→98`). Renumbered all 143 items strictly sequentially — ordinals only, no body/heading text changed.

## Versioning

Additive content/template + docs only — no changes to CLI flags, Python API, schemas, or on-disk artifact formats (per `STABILITY.md`). Stays under `[Unreleased]`; no tag/`pyproject` bump (mid-soak on `1.0.0rc6`, final promotion not before 2026-06-03 — a release decision for the maintainer).

## Tests

`test_snapshot_comparison` and `test_doc_structure` pass. (Pre-existing, unrelated `test_memory_index_relevance` BM25 calibration failures persist on `main` independent of this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)