### PR TITLE
chore(orchestrator): pin model to Claude Opus 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--bridge-refresh` clobbered user-authored `CLAUDE.md` and
   `.claude/*` content.
 
+### changed
+
+- **Orchestrator model pinned to Claude Opus 4.8.** The tier-1
+  Orchestrator template front matter now declares
+  `model: ["Claude Opus 4.8 (copilot)"]` (was Claude Sonnet 4.6).
+  Scoped to the orchestrator only; all other agent templates remain on
+  Sonnet 4.6. Affects newly generated and re-rendered teams; existing
+  downstream teams pick it up on the next `--update --merge`. Example
+  `expected/orchestrator.agent.md` snapshots regenerated. No CLI/Python-API/
+  schema changes.
+
 ### fixed
 
 - **`emit`: preserve lost fence bodies as `.lost.<sid>.md`

--- a/agentteams/templates/universal/orchestrator.template.md
+++ b/agentteams/templates/universal/orchestrator.template.md
@@ -4,7 +4,7 @@ description: "Coordinates all agent operations for {PROJECT_NAME}: routes work t
 user-invokable: true
 tools: ['read', 'edit', 'search', 'execute', 'todo', 'agent']
 agents:{AGENT_SLUG_LIST}
-model: ["Claude Sonnet 4.6 (copilot)"]
+model: ["Claude Opus 4.8 (copilot)"]
 handoffs:
   - label: Produce / Revise Deliverable
     agent: primary-producer

--- a/examples/data-pipeline/expected/orchestrator.agent.md
+++ b/examples/data-pipeline/expected/orchestrator.agent.md
@@ -32,7 +32,7 @@ agents:
   - transform-expert
   - load-expert
   - weekly-report-expert
-model: ["Claude Sonnet 4.6 (copilot)"]
+model: ["Claude Opus 4.8 (copilot)"]
 handoffs:
   - label: Produce / Revise Deliverable
     agent: primary-producer

--- a/examples/project-repositories/expected/orchestrator.agent.md
+++ b/examples/project-repositories/expected/orchestrator.agent.md
@@ -32,7 +32,7 @@ agents:
   - prairie-prosperity-expert
   - sugarscape-expert
   - visualize-energy-data-expert
-model: ["Claude Sonnet 4.6 (copilot)"]
+model: ["Claude Opus 4.8 (copilot)"]
 handoffs:
   - label: Produce / Revise Deliverable
     agent: primary-producer

--- a/examples/research-project/expected/orchestrator.agent.md
+++ b/examples/research-project/expected/orchestrator.agent.md
@@ -32,7 +32,7 @@ agents:
   - tool-pandoc
   - ch01-introduction-expert
   - ch02-literature-expert
-model: ["Claude Sonnet 4.6 (copilot)"]
+model: ["Claude Opus 4.8 (copilot)"]
 handoffs:
   - label: Produce / Revise Deliverable
     agent: primary-producer

--- a/examples/software-project/expected/orchestrator.agent.md
+++ b/examples/software-project/expected/orchestrator.agent.md
@@ -27,7 +27,7 @@ agents:
   - tool-postgresql
   - auth-module-expert
   - tasks-api-expert
-model: ["Claude Sonnet 4.6 (copilot)"]
+model: ["Claude Opus 4.8 (copilot)"]
 handoffs:
   - label: Produce / Revise Deliverable
     agent: primary-producer


### PR DESCRIPTION
## Summary

Pins the tier-1 Orchestrator template to **Claude Opus 4.8**. Front-matter `model:` changes from `["Claude Sonnet 4.6 (copilot)"]` to `["Claude Opus 4.8 (copilot)"]`.

Scoped to the **orchestrator only** — every other agent template remains on Sonnet 4.6. The front-matter value is authoritative: the copilot-vscode adapter only injects a default model when the key is absent, so the template value is preserved verbatim.

## Changes

- `agentteams/templates/universal/orchestrator.template.md`: `model:` field
- regenerated `expected/orchestrator.agent.md` for all four example teams (model-line-only diffs; project-repositories' unrelated pre-existing drift deliberately left untouched)
- CHANGELOG `[Unreleased] → changed` entry

## Versioning

Content-only; no CLI flag, Python API, schema, or on-disk artifact contract changes (per `STABILITY.md`) — non-breaking, stays under `[Unreleased]`, no tag/`pyproject` bump.

## Scope notes

- Affects **newly generated / re-rendered** teams. Existing downstream teams adopt Opus 4.8 only on their next `--update --merge`.
- `collector-management` carries its own "Model selection is fixed: Claude Sonnet 4.6" constitutional rule, which would conflict on propagation — not reconciled here.

## Tests

`test_snapshot_comparison`, `test_doc_structure`, and orchestrator contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)