### PR TITLE
chore(reconcile): man page + CHANGELOG data-safety trilogy + allowlist comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `tests/test_work_summary_backfill.py`; plan + adversarial/conflict audits under
     `references/plans/work-summary-backfill-integration-2026-06-15.plan.md`.
 
+- **Data-safety hardening for the output tree — atomic writes, integrity
+  verification, and bounded + mirrored backups.** Three coordinated capabilities
+  that make generated output recoverable and tamper-evident:
+  - **Atomic agent-file writes.** Generated agent files, their sidecars, and
+    `--restore-backup` now write to a temp file and `os.replace` it into place, so
+    an interrupted run can never leave a half-written or truncated agent file.
+  - **Integrity verification (read-only).** `--verify-integrity` classifies every
+    generated file against the build-log `file_hashes` baseline as `OK` /
+    `MODIFIED` / `TRUNCATED` / `MISSING` / `FENCE-BROKEN`, exiting non-zero on
+    `TRUNCATED`/`MISSING`/`FENCE-BROKEN` (`MODIFIED` is advisory). `--verify-backup
+    [TIMESTAMP]` confirms a backup is restorable by checking each file's bytes
+    against the `source_sha256` in its `_manifest.json`. Unlike `--update`, these
+    exit codes ARE the verdict.
+  - **Backup retention + off-machine mirror.** `--prune-backups [KEEP]` bounds
+    `.agentteams-backups/` growth (default keep 10) and never deletes the single
+    newest backup (even `KEEP 0`); `--keep-within-days DAYS` unions an age rule, and
+    an indeterminate-age backup is kept (fail-safe). `--backup-mirror DIR` (or the
+    `AGENTTEAMS_BACKUP_MIRROR` env var) copies each backup to a second location
+    (e.g. a NAS or synced folder), best-effort and non-fatal, so the recovery net
+    survives local disk loss. Tests in `tests/test_verify.py` and
+    `tests/test_backup_retention.py`.
+
 ### changed
 
 - **Repository filing conventions — stray plan docs no longer land at the root.**

--- a/agentteams.1
+++ b/agentteams.1
@@ -136,7 +136,7 @@ Optional source framework override for \-\-bridge\-from (auto\-detected when omi
 Check bridge freshness against source files without regenerating bridge artifacts.
 .TP
 .B \-\-bridge\-refresh
-Refresh bridge artifacts AND overwrite target\-framework entry files (CLAUDE.md, .claude/agent\-team.md, etc.). Destructive at the target — use \-\-bridge\-merge for non\-destructive updates.
+Refresh bridge artifacts AND overwrite target\-framework entry files (e.g. CLAUDE.md, .claude/*, AGENTS.md, .goosehints). Destructive at the target — note AGENTS.md is a SHARED multi\-tool file; use \-\-bridge\-merge for non\-destructive updates.
 .TP
 .B \-\-bridge\-merge
 Non\-destructive update: regenerate bridge\-internal artifacts, and for target\-framework entry files only re\-render content inside <!\-\- AGENTTEAMS\-BRIDGE:BEGIN ... \-\-> fences. Files lacking any bridge fence are skipped with notices in bridge\-merge.report.md. First\-time consumers should use \-\-bridge\-refresh.

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -38,8 +38,10 @@ MAX_MODULE_LINES = 1000
 LENGTH_ALLOWLIST: frozenset[str] = frozenset({
     # build_team.py left at Step D (now a 833-line shim); cli/app.py left at Step D2
     # (1174 -> 263 after the generate pipeline moved to cli/generate.py, 939 lines).
-    "agentteams/analyze.py",    # 1503 — accepted tracked debt (CH-07 allowlist; not split)
-    "agentteams/emit.py",       # 1389 — accepted tracked debt (CH-07 allowlist; not split)
+    "agentteams/analyze.py",    # 1504 — accepted tracked debt (CH-07 allowlist; not split)
+    "agentteams/emit.py",       # 1584 — accepted tracked debt (CH-07 allowlist; not split).
+    # NOTE: emit.py is accreting (1389 -> 1584 after backup retention/mirror + verify).
+    # Standing revisit-trigger: split it the next time a feature must touch it heavily.
 })
 BROAD_EXCEPT_BASELINE = 11      # except Exception/BaseException/bare. Narrowed over the sweep
                                 # (Steps E + remaining-items I6: commands, render_pipeline, ingest,


### PR DESCRIPTION
Post-merge reconciliation of three decision-free loose-ends left on `main` after the Goose Phase 2/3 **direct merges** (`5efdf84`). The full suite was already green (1363 passed); these are gaps pytest does not catch.

## What
- **Man page** — regenerate `agentteams.1`. Goose Phase 2 generalized the `--bridge-refresh` help (the "AGENTS.md is a shared multi-tool file" warning) but did not regenerate the committed page → the `ci.yml` man-currency step would fail on the next PR.
- **CHANGELOG** — one `[Unreleased]` entry documenting the **data-safety remediation trilogy** that shipped without one: atomic agent-file writes, `--verify-integrity`/`--verify-backup`, and `--prune-backups`/`--keep-within-days`/`--backup-mirror`. Claims scoped to what the code actually does (entry-file writes + restores are atomic; backup copies are not). No `tmp/` paths (RSR1).
- **`test_code_hygiene.py`** — refresh stale `LENGTH_ALLOWLIST` size comments (analyze 1503→1504, emit 1389→1584) + note `emit.py` is accreting, with the split as the standing revisit-trigger.

No code/behavior change.

## Verification
- Full suite: **1363 passed**
- Man currency (CI-exact diff): **current**
- RSR1 durable→tmp guard: **clean**
- Length-guard: **green** (comments are free-text, not parsed)

## Audit
Plan written, then passed through adversarial + conflict audits before implementation. Findings folded in: scoped the atomic-writes claim (avoid overclaim), kept `tmp/` out of the CHANGELOG entry (RSR1 blocker), appended the entry at the first `### added` block tail and regenerated the man page last (minimize collision with the active goose-on-main conversation, which edits these files and merges direct-to-main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)