### PR TITLE
feat(goose): convert teams TO Goose (Phase 4); refuse interop-to-goose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `references/bridge-refresh-safety.md`. Adapter
   `agentteams/frameworks/agents_md.py`; tests `tests/test_agents_md_framework.py`.
 
+- **`--convert-from … --framework goose` — Goose is now a conversion target
+  (Goose Phase 4).** Converting an existing team to Goose emits `.goose/recipes/*.yaml`,
+  a repo-root `AGENTS.md` (team brief, front matter stripped), and the `.goosehints`
+  integrator. The orchestrator's `sub_recipes` delegation wires from sources that keep
+  handoffs in their agent files (`copilot-vscode`); `claude`/`copilot-cli` sources strip
+  handoffs at their own generation, so they convert to valid but flat recipes (a
+  source-format limitation, not a conversion defect). Implemented as five general,
+  adapter-driven fixes in `convert.py` (instructions dest via `finalize_output_path`,
+  render-through-adapter, sidecar emission, team-roster reconstruction, builder routing)
+  — **no `goose.py` changes**. `--interop-from … --framework goose` is intentionally
+  **refused**: the CAI interop representation drops the handoff graph, so the result
+  would be unwired — use `--convert-from` for Goose. Tests in
+  `tests/test_goose_convert_interop.py`.
+
 ### changed
 
 - **Repository filing conventions — stray plan docs no longer land at the root.**

--- a/agentteams/cli/parser.py
+++ b/agentteams/cli/parser.py
@@ -746,6 +746,19 @@ def _validate_option_combinations(parser: argparse.ArgumentParser, args: argpars
                     f"target framework (copilot-vscode, copilot-cli, claude, goose)."
                 )
 
+    # interop-to-goose is refused: the canonical interop representation (CAI) drops
+    # the handoff graph (export_to_cai strips handoff blocks + sets handoffs=[]), so
+    # the Goose orchestrator would emit zero sub_recipes — a disconnected pile of
+    # recipes that is not a working team. --convert-from preserves handoffs (from the
+    # source agent content) and IS supported. (Bridge-to-goose has its own path.)
+    if getattr(args, "framework", None) == "goose" and getattr(args, "interop_from", None):
+        parser.error(
+            "--interop-from with --framework goose is not supported: the interop "
+            "representation drops the handoff graph Goose needs for sub_recipe "
+            "delegation, so the result would be unwired. Use "
+            "`--convert-from <team> --framework goose` instead (it preserves delegation)."
+        )
+
     if args.convert_from and args.interop_from:
         parser.error("--convert-from and --interop-from are mutually exclusive")
 

--- a/agentteams/convert.py
+++ b/agentteams/convert.py
@@ -140,9 +140,22 @@ def convert_team(
     if not source_dir.is_dir():
         raise FileNotFoundError(f"Source directory not found: {source_dir}")
 
-    manifest: dict[str, Any] = project_manifest or {}
+    manifest: dict[str, Any] = dict(project_manifest or {})
     adapter: FrameworkAdapter = _ADAPTERS[target_framework]()
     result = ConvertResult(dry_run=dry_run)
+
+    # F4 — reconstruct the team roster so team-aware adapters (goose) can wire the
+    # orchestrator's sub_recipe delegation. goose._team_slugs reads manifest
+    # ``output_files`` for ``*.agent.md`` slugs, so synthesize that path shape from
+    # the source agent files regardless of the target framework's own extension.
+    # (Delegation also needs each agent's handoffs, which live in the source agent
+    # content — fully present for copilot-vscode sources; claude/copilot-cli strip
+    # handoffs at their own generation, so those sources convert to valid-but-flat
+    # recipes. That is a source-format limitation, not a conversion defect.)
+    team_slugs = _collect_source_slugs(source_dir)
+    manifest["output_files"] = list(manifest.get("output_files", [])) + [
+        {"path": f"{slug}.agent.md"} for slug in team_slugs
+    ]
 
     # Walk source directory shallowly first, then handle subdirs explicitly
     for entry in sorted(source_dir.iterdir()):
@@ -157,6 +170,18 @@ def convert_team(
     for candidate in sorted(parent_dir.iterdir()):
         if candidate.is_file() and candidate.name in _INSTRUCTIONS_NAMES:
             _convert_file(candidate, target_dir, adapter, manifest, dry_run, overwrite, result)
+
+    # F3 — emit framework sidecars not derived from a source file (goose's repo-root
+    # ``.goosehints`` integrator). Paths are relative to the agents dir, like emit.py.
+    for rel_path, content in adapter.extra_output_files(manifest):
+        dest = (target_dir / rel_path).resolve()
+        if dest.exists() and not overwrite:
+            result.skipped.append(str(dest))
+            continue
+        if not dry_run:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+        result.converted.append(str(dest))
 
     return result
 
@@ -248,17 +273,22 @@ def _convert_file(
         return
 
     if file_type == "instructions":
-        # Place the instructions file at the project root (parent of agents dir)
-        # using the name required by the target framework.
-        root_dir = target_dir.parent
-        instructions_name = _target_instructions_name(adapter)
-        dest = root_dir / instructions_name
+        # F1 — adapter-driven dest. ``finalize_output_path`` returns the instructions
+        # path RELATIVE TO THE AGENTS DIR for the target framework: claude →
+        # ``../CLAUDE.md``, copilot → ``../copilot-instructions.md`` (both equal the
+        # legacy ``target_dir.parent/<name>`` placement), goose → ``../../AGENTS.md``
+        # (the repo root, since ``.goose/recipes`` is two levels deep).
+        rel = adapter.finalize_output_path("../copilot-instructions.md", "instructions")
+        dest = (target_dir / rel).resolve()
         if dest.exists() and not overwrite:
             result.skipped.append(str(source_path))
             return
         content = source_path.read_text(encoding="utf-8")
+        # F2 — render through the adapter (e.g. goose strips front matter for AGENTS.md)
+        # instead of copying verbatim.
+        content = adapter.render_instructions_file(content, manifest)
         if not dry_run:
-            root_dir.mkdir(parents=True, exist_ok=True)
+            dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_text(content, encoding="utf-8")
         result.converted.append(str(dest))
         return
@@ -274,7 +304,12 @@ def _convert_file(
     try:
         content = source_path.read_text(encoding="utf-8")
         slug = source_path.stem.replace(".agent", "")
-        converted_content = adapter.render_agent_file(content, slug, manifest)
+        if file_type == "builder":
+            # F5 — frameworks whose agent files are not plain markdown (goose recipes)
+            # wrap the builder differently from a specialist agent.
+            converted_content = adapter.render_builder_file(content, manifest)
+        else:
+            converted_content = adapter.render_agent_file(content, slug, manifest)
     except Exception as exc:  # noqa: BLE001
         result.errors.append(f"{source_path}: {exc}")
         return
@@ -325,15 +360,15 @@ def _convert_subdir(
                 _convert_file(entry, nested_target, adapter, manifest, dry_run, overwrite, result)
 
 
-def _target_instructions_name(adapter: FrameworkAdapter) -> str:
-    """Return the instructions file name for the given adapter.
+def _collect_source_slugs(source_dir: Path) -> list[str]:
+    """Return the agent/builder slugs present in *source_dir* (F4 team roster).
 
-    Args:
-        adapter: Target framework adapter.
-
-    Returns:
-        File name string (e.g. ``"CLAUDE.md"`` or ``"copilot-instructions.md"``).
+    Uses :func:`_classify_source_file` so it works for both ``*.agent.md``
+    (copilot-vscode) and ``*.md`` (claude) sources. The slug is the filename stem
+    minus any ``.agent`` segment, matching the convention every adapter uses.
     """
-    if adapter.framework_id == "claude":
-        return "CLAUDE.md"
-    return "copilot-instructions.md"
+    slugs: list[str] = []
+    for entry in sorted(source_dir.iterdir()):
+        if entry.is_file() and _classify_source_file(entry) in {"agent", "builder"}:
+            slugs.append(entry.stem.replace(".agent", ""))
+    return slugs

--- a/docs_src/cli-reference.md
+++ b/docs_src/cli-reference.md
@@ -72,8 +72,8 @@ Convert an existing team from `DIR` into the target `--framework` instead of ren
 
 - Preserves agent body prose.
 - Replaces front matter and framework wrappers.
-- Converts instructions naming (`copilot-instructions.md` <-> `CLAUDE.md`) based on target.
-- Supports all six directional combinations between `copilot-vscode`, `copilot-cli`, and `claude`.
+- Converts instructions naming (`copilot-instructions.md` / `CLAUDE.md` / repo-root `AGENTS.md` for goose) based on target, and emits target sidecars (e.g. goose's `.goosehints`).
+- Supports the six directional combinations between `copilot-vscode`, `copilot-cli`, and `claude`, **and converting any of them to `goose`** (writes `.goose/recipes/*.yaml` + repo-root `AGENTS.md`). Orchestrator delegation (`sub_recipes`) wires from sources that preserve handoffs in their agent files — i.e. `copilot-vscode`; `claude`/`copilot-cli` sources strip handoffs at their own generation, so they convert to valid but flat (un-delegated) recipes.
 - Non-dry-run conversions run the same live security freshness preflight as the main render path; stale or unavailable security intel blocks writes unless a valid signed waiver exists in `references/security-waivers.log.csv` and `AGENTTEAMS_WAIVER_SIGNING_KEY` is configured.
 
 ### `--interop-from DIR`
@@ -82,6 +82,7 @@ Run the CAI-based interop pipeline from an existing source team.
 
 - `direct` mode writes target framework files.
 - `bundle` mode writes target files and compatibility artifacts under `references/interop/<source>-to-<target>/`.
+- **`--framework goose` is not supported as an interop target** — the canonical interop representation (CAI) does not carry the handoff graph Goose needs for `sub_recipe` delegation, so the result would be unwired. Use `--convert-from … --framework goose` instead (it preserves delegation from the source agent files).
 - Non-dry-run interop runs also enforce the live security freshness preflight before writing, with the same signed-waiver exception path.
 
 ### `--interop-source-framework NAME`

--- a/tests/test_goose_convert_interop.py
+++ b/tests/test_goose_convert_interop.py
@@ -1,0 +1,139 @@
+"""Tests for Goose as a convert TARGET (Goose Phase 4).
+
+`--convert-from <team> --framework goose` produces valid Goose recipes + a repo-root
+AGENTS.md + .goosehints; delegation (orchestrator sub_recipes) wires from sources that
+preserve handoffs (copilot-vscode). `--interop-from … --framework goose` is intentionally
+REFUSED (the CAI representation drops the handoff graph → zero delegation)."""
+from __future__ import annotations
+
+import io
+import re
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+import build_team
+from agentteams.convert import convert_team
+
+_BRIEF = "examples/data-pipeline/brief.json"
+pytestmark = pytest.mark.skipif(not Path(_BRIEF).exists(), reason="data-pipeline brief not found")
+
+
+def _gen_source(root: Path, framework: str) -> Path:
+    """Generate a real source team in *root* and return its agents dir."""
+    agents = {
+        "copilot-vscode": root / ".github" / "agents",
+        "claude": root / ".claude" / "agents",
+    }[framework]
+    rc = build_team.main([
+        "--description", _BRIEF, "--framework", framework,
+        "--output", str(agents), "--yes", "--no-scan",
+    ])
+    assert rc == 0
+    return agents
+
+
+@pytest.fixture(scope="module")
+def copilot_source(tmp_path_factory):
+    return _gen_source(tmp_path_factory.mktemp("cv-src"), "copilot-vscode")
+
+
+@pytest.fixture(scope="module")
+def claude_source(tmp_path_factory):
+    return _gen_source(tmp_path_factory.mktemp("cl-src"), "claude")
+
+
+def _orchestrator_subrecipes(recipes_dir: Path) -> list[str]:
+    orch = recipes_dir / "orchestrator.yaml"
+    if not orch.exists():
+        return []
+    return re.findall(r'path:\s*"?\./([A-Za-z0-9_-]+\.yaml)"?', orch.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# convert copilot-vscode -> goose (full fidelity: source keeps handoffs)
+# ---------------------------------------------------------------------------
+
+def test_convert_copilot_to_goose_emits_recipes_and_repo_root_files(copilot_source, tmp_path):
+    tgt_root = tmp_path / "proj"
+    recipes = tgt_root / ".goose" / "recipes"
+    res = convert_team(copilot_source, recipes, "goose", project_manifest={"project_name": "P"})
+    assert res.errors == []
+    assert (recipes / "orchestrator.yaml").exists()
+    assert list(recipes.glob("*.yaml"))                      # per-agent recipes
+    # repo-root sidecars (two levels above .goose/recipes)
+    agents_md = tgt_root / "AGENTS.md"
+    assert agents_md.exists(), "AGENTS.md must land at the repo root"
+    assert not agents_md.read_text(encoding="utf-8").startswith("---")  # front matter stripped
+    assert (tgt_root / ".goosehints").exists()
+
+
+def test_convert_copilot_to_goose_wires_delegation(copilot_source, tmp_path):
+    recipes = tmp_path / "proj" / ".goose" / "recipes"
+    convert_team(copilot_source, recipes, "goose", project_manifest={"project_name": "P"})
+    subs = _orchestrator_subrecipes(recipes)
+    assert subs, "orchestrator must declare sub_recipes (delegation wired from copilot handoffs)"
+    # every sub_recipe path must resolve on disk (goose recipe validate does NOT check this)
+    unresolved = [s for s in subs if not (recipes / s).exists()]
+    assert unresolved == [], f"dangling sub_recipe paths: {unresolved}"
+
+
+# ---------------------------------------------------------------------------
+# convert claude -> goose (valid output; delegation may be flat — claude strips
+# handoffs at its own generation, so this is a source-format limitation)
+# ---------------------------------------------------------------------------
+
+def test_convert_claude_to_goose_emits_valid_recipes(claude_source, tmp_path):
+    tgt_root = tmp_path / "proj"
+    recipes = tgt_root / ".goose" / "recipes"
+    res = convert_team(claude_source, recipes, "goose", project_manifest={"project_name": "P"})
+    assert res.errors == []
+    assert (recipes / "orchestrator.yaml").exists()
+    assert (tgt_root / "AGENTS.md").exists()
+    assert (tgt_root / ".goosehints").exists()
+
+
+# ---------------------------------------------------------------------------
+# F1 backward-compatibility: convert to claude/copilot is unchanged
+# ---------------------------------------------------------------------------
+
+def test_convert_to_claude_still_places_claude_md_at_legacy_location(copilot_source, tmp_path):
+    tgt_root = tmp_path / "proj"
+    recipes = tgt_root / ".claude" / "agents"
+    res = convert_team(copilot_source, recipes, "claude", project_manifest={"project_name": "P"})
+    assert res.errors == []
+    # legacy convention: instructions at target_dir.parent (.claude/CLAUDE.md)
+    assert (tgt_root / ".claude" / "CLAUDE.md").exists()
+    assert list(recipes.glob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# interop-to-goose is refused (zero-delegation guard)
+# ---------------------------------------------------------------------------
+
+def _validate(argv):
+    from agentteams.cli.parser import _build_parser, _validate_option_combinations
+    parser = _build_parser()
+    _validate_option_combinations(parser, parser.parse_args(argv))
+
+
+def test_interop_to_goose_is_refused(tmp_path):
+    err = io.StringIO()
+    with pytest.raises(SystemExit) as exc, redirect_stderr(err):
+        _validate(["--interop-from", str(tmp_path), "--framework", "goose",
+                   "--output", str(tmp_path / "o")])
+    assert exc.value.code == 2
+    assert "interop-from with --framework goose is not supported" in err.getvalue()
+
+
+def test_convert_to_goose_is_not_refused(tmp_path):
+    # convert-to-goose IS supported → validation must NOT raise.
+    _validate(["--convert-from", str(tmp_path), "--framework", "goose",
+               "--output", str(tmp_path / "o")])
+
+
+def test_interop_to_other_frameworks_still_allowed(tmp_path):
+    # the refusal is goose-specific; interop to claude must still validate cleanly.
+    _validate(["--interop-from", str(tmp_path), "--framework", "claude",
+               "--output", str(tmp_path / "o")])


### PR DESCRIPTION
Lifts the "Convert/interop **to** Goose … deferred" gap (Goose Phase 4). The user reassigned this from the parallel Goose conversation; it touches **no `goose.py`** to stay collision-free with that work.

## What works
`--convert-from <team> --framework goose` emits valid Goose output — `.goose/recipes/*.yaml`, a repo-root `AGENTS.md` (team brief, front matter stripped), and the `.goosehints` integrator — with the orchestrator's `sub_recipes` **delegation wired** (19 sub_recipes for the data-pipeline example, all paths resolving on disk; passes the real `goose recipe validate`).

Five general, adapter-driven fixes in `convert.py` (each correct for every framework, enabling goose):
- **F1** instructions dest via `adapter.finalize_output_path` — claude/copilot **byte-identical** to today; goose → repo-root `AGENTS.md`.
- **F2** render instructions through the adapter (goose strips front matter) instead of verbatim copy.
- **F3** emit `adapter.extra_output_files` (goose's `.goosehints`; no-op for others).
- **F4** reconstruct the team roster (`manifest["output_files"]` from source slugs via `_classify_source_file`) so `goose._team_slugs` wires `sub_recipes`.
- **F5** route the builder through `render_builder_file`.

**Fidelity (documented, honest):** delegation wires from sources that keep handoffs in their agent files (`copilot-vscode`); `claude`/`copilot-cli` strip handoffs at *their* generation → convert to valid-but-flat recipes (source-format limitation, not a conversion defect).

## What's refused
`--interop-from … --framework goose` is **refused** (parser guard). The adversarial auditor built and ran it: the CAI representation drops the handoff graph (`export_to_cai` sets `handoffs=[]`), so the orchestrator gets **zero** sub_recipes — a disconnected pile, not a team. The guard points users to `--convert-from`. (Resolves the adversarial "refuse" vs conflict "ship-degraded" split in favor of refuse — zero delegation is misleading.)

## Audit (both plans)
Plans written → adversarial + conflict audits (auditors **built and ran** the change against the real `goose` CLI) → revised → implemented. The audits also caught that the *separate* `drift.py:317` "bug" (open item #1) was a **false positive**: the diff compares the manifest's pre-finalized path (`../copilot-instructions.md`), which the current code already matches — the proposed fix would have **regressed** it. Verified empirically; **abandoned, no change**.

## Verification
- **Full suite: 1385 passed** (1378 + 7 new in `tests/test_goose_convert_interop.py`)
- No regression: `test_interop` / `test_drift` / `test_frameworks` / `test_learnpython_generation` (169) green
- Man currency, RSR1, code-hygiene guards: green
- `interop.py` untouched (refusal lives in `parser.py`)

> Not self-merging: Phase 4 was the parallel Goose conversation's deferred work — leaving the merge to you to coordinate. `main` was re-checked unmoved on `convert.py`/`interop.py`/`parser.py` at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)