### PR TITLE
fix(interop): export_to_cai must not treat reference/backup .md as agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would be unwired — use `--convert-from` for Goose. Tests in
   `tests/test_goose_convert_interop.py`.
 
+### fixed
+
+- **`--interop-from` no longer emits reference docs (or backup copies) as bogus
+  agents.** `export_to_cai` walked the source tree recursively and treated every
+  `.md` it found as an agent, so `references/*.md` (and, when present, agent copies
+  under `.agentteams-backups/`) were exported as ~13–14 spurious "agents" per team.
+  The export now skips non-agent subdirectories (`references`, `skills`,
+  `.agentteams-backups`), mirroring `convert.py`'s passthrough handling, so interop
+  emits only the real agents. Test in `tests/test_interop.py`.
+
 ### changed
 
 - **Repository filing conventions — stray plan docs no longer land at the root.**

--- a/agentteams/interop.py
+++ b/agentteams/interop.py
@@ -18,6 +18,10 @@ from typing import Any
 from agentteams.frameworks.registry import FRAMEWORKS as _ADAPTERS
 
 _INSTRUCTIONS_NAMES = {"copilot-instructions.md", "CLAUDE.md"}
+# Subdirectories under (or beside) an agents dir whose .md files are NOT agents:
+# reference docs, Claude skills (a sibling dir), and backup copies of agents.
+# Mirror of convert._PASSTHROUGH_DIRS (kept in sync deliberately — see convert.py).
+_NON_AGENT_DIRS = {"references", "skills", ".agentteams-backups"}
 _YAML_FRONT_MATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
 
 
@@ -84,6 +88,10 @@ def export_to_cai(source_dir: Path, source_framework: str | None = None) -> dict
         if entry.is_dir():
             continue
         rel = entry.relative_to(source_dir)
+        if rel.parts and rel.parts[0] in _NON_AGENT_DIRS:
+            # reference docs / skills / backup copies — never agents (rglob recurses,
+            # so without this every references/*.md became a bogus CAI agent)
+            continue
         name = entry.name
         if name in _INSTRUCTIONS_NAMES:
             instructions_name = name

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -434,3 +434,27 @@ def test_chained_a_to_b_to_c_not_worse_than_direct_a_to_c(
     chained_token_counts = _token_counts(chained_text, critical_tokens)
     for token in critical_tokens:
         assert chained_token_counts[token] >= direct_token_counts[token]
+
+
+def test_export_to_cai_excludes_reference_and_backup_md(tmp_path):
+    """export_to_cai must not slurp non-agent .md files (reference docs, skills,
+    or backup copies) as agents — only the real flat agent files."""
+    from agentteams.interop import export_to_cai
+
+    agents_dir = tmp_path / ".github" / "agents"
+    _build_source("copilot-vscode", agents_dir)  # writes orchestrator.agent.md
+
+    # Decoys that the recursive rglob would otherwise pick up as agents:
+    refs = agents_dir / "references"
+    refs.mkdir()
+    (refs / "pipeline-graph.md").write_text("# Pipeline\n\nnot an agent\n", encoding="utf-8")
+    (refs / "ref-pandas-reference.md").write_text("# pandas\n\nnot an agent\n", encoding="utf-8")
+    backup = agents_dir / ".agentteams-backups" / "20260615-000000"
+    backup.mkdir(parents=True)
+    (backup / "orchestrator.agent.md").write_text(_vscode_agent("orchestrator"), encoding="utf-8")
+
+    cai = export_to_cai(agents_dir, source_framework="copilot-vscode")
+    slugs = sorted(a["slug"] for a in cai["agents"])
+    assert slugs == ["orchestrator"], f"expected only the real agent, got {slugs}"
+    # the decoy filenames must not appear as agents under any slug form
+    assert not any("pipeline" in s or "reference" in s or "pandas" in s for s in slugs)


### PR DESCRIPTION
**Item #4** — pre-existing interop bug found by the Phase-4 adversarial auditor.

`export_to_cai` walked `source_dir.rglob("*")` and treated every `.md` (except `SETUP-REQUIRED.md` + instructions) as an agent → `references/*.md` reference docs became **bogus CAI agents** (~13–14 per team), and — when the source had been `--update`d before — agent copies under `.agentteams-backups/` became **duplicate** agents.

## Fix
Skip non-agent subdirectories (`references`, `skills`, `.agentteams-backups`) via a first-path-component check, mirroring `convert.py`'s `_PASSTHROUGH_DIRS`. Agent files are always flat in the agents dir, so this drops no real agent.

## Audit
- **Adversarial** (ran it): junk **14/13 → 0**, real agent count unchanged across copilot-vscode / copilot-cli / claude; `rel.parts` edge cases safe; 146/146 interop-touching tests pass.
- **Conflict**: found the `.agentteams-backups` duplicate-agent case (folded into the exclusion set); recommended the `### fixed` CHANGELOG entry; confirmed land-#4-before-#2/#3.

## Verification
Full suite **1386 passed**; RSR1 + compile green; new test in `tests/test_interop.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)