### PR TITLE
docs(cli): framework feature-support matrix (goose availability)

### DIFF
--- a/docs_src/cli-reference.md
+++ b/docs_src/cli-reference.md
@@ -56,6 +56,33 @@ Target agent framework. Choices: `copilot-vscode` (default), `copilot-cli`, `cla
 
 `references/runtime-handoffs.json` is a framework-neutral sidecar manifest emitted when extracted handoffs exist for frameworks that do not keep inline VS Code handoff syntax in the final agent file.
 
+#### Feature support by framework
+
+`--framework` selects the **target** of each pipeline. Not every framework is a valid target for every pipeline:
+
+| Framework | Generate | Convert target | Interop target | Bridge target |
+|-----------|:--------:|:--------------:|:--------------:|:-------------:|
+| `copilot-vscode` | ✓ | ✓ | ✓ | ✓ |
+| `copilot-cli` | ✓ | ✓ | ✓ | ✓ |
+| `claude` | ✓ | ✓ | ✓ | ✓ |
+| `goose` | ✓ | ✓ <sup>1</sup> | ✗ *(planned)* <sup>2</sup> | ✓ |
+| `agents-md` | ✓ | ✗ <sup>3</sup> | ✗ <sup>3</sup> | ✗ <sup>3</sup> |
+
+**✓** available · **✗** not a valid target (by design) · **✗ *(planned)*** not yet developed
+
+- **Generate** — `--framework X --description …` (or `--self`).
+- **Convert target** — `--convert-from <team> --framework X` (format migration).
+- **Interop target** — `--interop-from <team> --framework X` (CAI pipeline).
+- **Bridge target** — `--bridge-from <team> --framework X` (lightweight pointer artifacts).
+
+<sup>1</sup> `goose` convert wires full orchestrator delegation (`sub_recipes`) from `copilot-vscode` sources (which keep handoffs inline in their agent files). `claude` / `copilot-cli` sources strip handoffs at their own generation, so they currently convert to valid but **flat (un-delegated)** recipes; recovering that delegation from the `runtime-handoffs.json` sidecar is part of the planned handoff-recovery work.
+
+<sup>2</sup> `--interop-from … --framework goose` is **not yet developed**: the canonical interop (CAI) representation drops the handoff graph Goose needs for `sub_recipes` delegation, so the result would be unwired. Use `--convert-from … --framework goose` instead. Enabling interop-to-goose (by preserving handoffs through the CAI) is planned.
+
+<sup>3</sup> `agents-md` is **generate-only** by design — it emits the cross-tool `AGENTS.md` standard and is intentionally not a convert/interop/bridge target.
+
+Auto-detected **source** frameworks (for `--convert-from` / `--interop-from` / `--bridge-from` without an explicit `--*-source-framework`) are `copilot-vscode`, `copilot-cli`, and `claude`; `goose` and `agents-md` are not auto-detected as sources.
+
 ### `--output DIR` / `-o DIR`
 
 Output directory for generated agent files. Defaults by framework:


### PR DESCRIPTION
The `--framework` table documented each target's *format* but not which *pipelines* it supports. Adds a **capability matrix** so it's clear which features are available per framework and which are not yet developed.

| Framework | Generate | Convert | Interop | Bridge |
|---|:-:|:-:|:-:|:-:|
| copilot-vscode / copilot-cli / claude | ✓ | ✓ | ✓ | ✓ |
| **goose** | ✓ | ✓ ¹ | ✗ *(planned)* ² | ✓ |
| agents-md | ✓ | ✗ | ✗ | ✗ |

- **goose**: Generate (Phase 1), Convert target (Phase 4), Bridge target (Phase 2) are **available**; **Interop target is not yet developed** (the CAI representation drops the handoff graph → use `--convert-from`; enabling it is the planned handoff-recovery work). Footnote notes `claude`/`copilot-cli`→goose convert to flat recipes until that work lands.
- **agents-md**: generate-only by design.
- Notes auto-detected source frameworks.

Docs-only (`docs_src` authoritative; deploy rebuilds on merge). mkdocs builds clean; doc-structure/root-hygiene/RSR1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)