### PR TITLE
docs(api): represent Goose across the API reference

### DIFF
--- a/docs_src/api-reference/convert.md
+++ b/docs_src/api-reference/convert.md
@@ -35,7 +35,7 @@ Args:
 
 1. `source_dir` (`Path`): source agent directory.
 2. `target_dir` (`Path`): destination agent directory.
-3. `target_framework` (`str`): one of `copilot-vscode`, `copilot-cli`, `claude`.
+3. `target_framework` (`str`): one of `copilot-vscode`, `copilot-cli`, `claude`, or `goose`. (`agents-md` is generate-only and is not a valid convert target.)
 4. `project_manifest` (`dict | None`): optional context for adapter rendering.
 5. `dry_run` (`bool`): simulate write operations.
 6. `overwrite` (`bool`): overwrite existing files when true.
@@ -54,5 +54,15 @@ Raises:
 ## Notes
 
 1. Preserves body prose while rewriting framework wrappers/front matter.
-2. Converts instructions file naming between `copilot-instructions.md` and `CLAUDE.md`.
-3. Copies passthrough assets such as `SETUP-REQUIRED.md` and `references/`.
+2. The instructions file is placed at the adapter's `finalize_output_path` location — `copilot-instructions.md`, `CLAUDE.md`, or, for `goose`, the repo-root `AGENTS.md` (front matter stripped) — and rendered through the target adapter's `render_instructions_file`.
+3. Emits any adapter sidecars via `extra_output_files` — e.g. `goose`'s repo-root `.goosehints` integrator.
+4. Copies passthrough assets such as `SETUP-REQUIRED.md` and `references/`.
+
+### Goose target (`--framework goose`)
+
+Converting an existing team to Goose emits one recipe per agent under `.goose/recipes/*.yaml`, plus the repo-root `AGENTS.md` + `.goosehints`. The orchestrator's `sub_recipes` delegation is reconstructed from each agent's handoffs:
+
+- **`copilot-vscode` sources** keep handoffs inline in their agent files, so delegation wires fully (identical to a native `--framework goose` generation).
+- **`claude` / `copilot-cli` sources** strip handoffs at their own generation (handoffs live in `references/runtime-handoffs.json`), so they currently convert to valid but **flat (un-delegated)** recipes. Recovering that delegation from the sidecar is planned (see the handoff-recovery work).
+
+`convert_team` synthesizes the team roster into `manifest["output_files"]` so the Goose adapter's `_team_slugs` can resolve delegation targets.

--- a/docs_src/api-reference/feature-inventory.md
+++ b/docs_src/api-reference/feature-inventory.md
@@ -75,12 +75,17 @@ Use this matrix when deciding which module/artifact to rely on for a specific op
 24. **`claude` Adapter** — Claude Code front matter `.md` + `CLAUDE.md`; outputs to `.claude/agents/`
 25. **Framework-Agnostic Interface** — Extensible adapter base class for adding new frameworks
 
+Two additional first-class adapters extend this set:
+
+- **`goose` Adapter** — Block / AAIF Goose recipe YAML (`.goose/recipes/*.yaml`, schema `1.0.0`); orchestrator delegation encoded natively as `sub_recipes` (deeper edges become `summon` `load(...)`); team brief written to the repo-root `AGENTS.md` plus a `.goosehints` integrator. Also a valid `--convert-from` and `--bridge-from` **target** (not an interop target). See [`frameworks`](frameworks.md).
+- **`agents-md` Adapter** — Cross-tool **AGENTS.md** standard (AAIF / Linux Foundation); emits a single framework-neutral repo-root `AGENTS.md` (read by ~10 AI coding tools) plus per-specialist detail under `.agents/`. **Generate-only** (not a convert/interop/bridge target).
+
 ### CLI
 
 26. **`agentteams` / `build_team.py` CLI** — Command-line interface wiring all pipeline stages
 27. **`--description`** — Path to project brief (`.json` or `.md`)
 28. **`--project`** — Target project directory
-29. **`--framework`** — Output framework: `copilot-vscode`, `copilot-cli`, or `claude`
+29. **`--framework`** — Output framework: `copilot-vscode`, `copilot-cli`, `claude`, `goose`, or `agents-md`
 30. **`--dry-run`** — Preview output without writing files
 31. **`--overwrite`** — Allow overwriting existing agent files
 32. **`--self`** — Self-maintenance: regenerate the module's own agent team
@@ -218,12 +223,12 @@ Workflows are step sequences embedded in the generated Orchestrator agent. Every
 
 ## Interoperability
 
-113. **`convert` Module** — Direct format migration between framework outputs (`copilot-vscode` ↔ `copilot-cli` ↔ `claude`)
-114. **`--convert-from` Flag** — Convert an existing agent team to a different framework format
+113. **`convert` Module** — Direct format migration between framework outputs (`copilot-vscode` ↔ `copilot-cli` ↔ `claude`), and to `goose` (emits recipes + repo-root `AGENTS.md` + `.goosehints`; delegation wired from `copilot-vscode` sources, flat from `claude`/`copilot-cli`)
+114. **`--convert-from` Flag** — Convert an existing agent team to a different framework format (targets: `copilot-vscode`, `copilot-cli`, `claude`, `goose`)
 115. **File Classification** — Auto-detect file role (agent, instruction, reference) for correct translation
-116. **`interop` Module** — Canonical Agent Interface (CAI) normalization and compatibility pipeline
+116. **`interop` Module** — Canonical Agent Interface (CAI) normalization and compatibility pipeline (`copilot-vscode` / `copilot-cli` / `claude` targets; `goose` is refused — the CAI does not carry the handoff graph Goose needs, so use `--convert-from` instead)
 117. **`--interop-from` Flag** — Run the CAI interop pipeline against an existing team
-118. **`bridge` Module** — Lightweight runtime compatibility bridge; generate bridge artifacts without regenerating sources
+118. **`bridge` Module** — Lightweight runtime compatibility bridge; generate bridge artifacts without regenerating sources (targets include `goose` — writes fenced `AGENTS.md` / `.goosehints` / `.goose/README.md` pointers)
 119. **`--bridge-from` Flag** — Generate bridge artifacts from a source canonical team
 120. **Runtime Handoff Manifest** — `references/runtime-handoffs.json`; emitted when handoffs are extracted from non-VS Code adapters, consumed by bridge layers and external tooling
 

--- a/docs_src/api-reference/frameworks.md
+++ b/docs_src/api-reference/frameworks.md
@@ -133,6 +133,16 @@ Post-process the rendered team-builder meta-agent. **Default implementation: ide
 
 **Returns:** `str` — Framework-shaped builder content.
 
+#### `extra_output_files(manifest)`
+
+Return additional `(rel_path, content)` files the framework emits that are not derived from a template. **Default implementation: empty list.** `GooseAdapter` overrides this to emit the repo-root `.goosehints` integrator alongside `AGENTS.md`. These files are emitted by the generate path **and** by `convert_team`, so a converted Goose team also gets its `.goosehints`.
+
+**Args:**
+
+- `manifest` (`dict[str, Any]`) — Team manifest.
+
+**Returns:** `list[tuple[str, str]]` — `(rel_path, content)` pairs, relative to the agents directory.
+
 ---
 
 ## `CopilotVSCodeAdapter`

--- a/docs_src/api-reference/interop.md
+++ b/docs_src/api-reference/interop.md
@@ -38,9 +38,11 @@ Returns one of:
 2. `copilot-cli`
 3. `claude`
 
+`detect_framework` does not auto-detect `goose` or `agents-md`; those are never inferred as interop **sources** (pass `--interop-source-framework` only for the three above).
+
 ### `export_to_cai(source_dir, source_framework=None)`
 
-Exports source team files to CAI payload.
+Exports source team files to CAI payload. Non-agent subdirectories — `references`, `skills`, and `.agentteams-backups` — are skipped, so reference docs and backup copies are never mistaken for agents.
 
 Returns CAI object with keys including:
 
@@ -75,3 +77,4 @@ Bundle artifacts are emitted under `references/interop/<source>-to-<target>/`.
 1. CAI path is intended for deterministic cross-framework transport.
 2. Bundle mode emits routing/instructions manifests for external consumers.
 3. Framework wrappers are normalized while preserving semantic markdown payload.
+4. **`goose` is not a supported interop target.** The CLI refuses `--interop-from … --framework goose`: the CAI representation does not carry the handoff graph Goose needs for `sub_recipes` delegation, so the result would be unwired. Use [`--convert-from … --framework goose`](convert.md) instead (it preserves delegation from the source agent files). Enabling interop-to-Goose, by preserving handoffs through the CAI, is planned.


### PR DESCRIPTION
The API reference predated Goose becoming a **convert/bridge target** and didn't reflect the **interop refusal**. This brings the Goose integration current across the reference pages.

- **convert.md** — `goose` added to valid targets; documents recipe + repo-root `AGENTS.md` + `.goosehints` emission and delegation fidelity (full from `copilot-vscode`, flat from `claude`/`copilot-cli`).
- **interop.md** — `goose` documented as **not** a supported interop target (CAI drops the handoff graph → use `--convert-from`); `export_to_cai` skips `references`/`skills`/`.agentteams-backups`; `detect_framework` doesn't auto-detect goose/agents-md.
- **frameworks.md** — documents the base `extra_output_files` hook (goose's `.goosehints`, emitted on generate **and** convert).
- **feature-inventory.md** — `goose` (+ `agents-md`) added to the Framework Adapters set; `--framework` widened; goose reflected as a convert/bridge target + interop refusal. Manual item numbering preserved (added as bullets, not new IDs).

Goose mentions: convert 0→7, interop 0→2, feature-inventory 0→6 (frameworks.md/bridge.md already covered it).

Docs-only; mkdocs builds clean (no new warnings); doc-structure/root-hygiene/RSR1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)