### PR TITLE
docs: mark Goose support as beta across all documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### added
 
-- **Goose (Block / AAIF) framework support.** Adds Goose as a first-class target
-  alongside Copilot and Claude:
+- **Goose (Block / AAIF) framework support (beta).** Adds Goose as a target
+  alongside Copilot and Claude. **Beta:** generate/convert/bridge are supported and
+  validated against the Goose CLI; interop-to-Goose is not yet supported and the
+  `goose` adapter API is not yet covered by the stability policy (`STABILITY.md`).
   - **Generate** (`--framework goose`): emits one Goose recipe per agent under
     `.goose/recipes/<slug>.yaml`, an `orchestrator.yaml` that delegates to specialist
     recipes via `sub_recipes` (deeper handoff edges become `summon` `load(...)`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Given a project description (a `.json` or `.md` brief), the module:
 1. **Analyzes** the project goal, deliverables, tools, and components
 2. **Selects** the right agent archetypes from a 4-tier taxonomy
 3. **Renders** all agent files by filling in project-specific placeholders
-4. **Emits** ready-to-use agent files for VS Code Copilot, Copilot CLI, Claude, or Goose
+4. **Emits** ready-to-use agent files for VS Code Copilot, Copilot CLI, Claude, or Goose *(beta)*
 
 The generated team includes:
 - 1 **Orchestrator** agent — coordinates all workflows
@@ -139,7 +139,9 @@ See the [Agent-Assisted Setup guide](https://jlcatonjr.github.io/agentteams/agen
 | `copilot-vscode` | `.agent.md` with YAML front matter | Native inline YAML | VS Code Copilot `.agent.md` |
 | `copilot-cli` | Plain `.md` system prompts | Runtime manifest when handoffs are present (`references/runtime-handoffs.json`) | CLI prompt `.md` |
 | `claude` | Claude Code front matter `.md` + `CLAUDE.md` instructions | Runtime manifest when handoffs are present (`references/runtime-handoffs.json`) | Claude Code system prompt |
-| `goose` | Recipe YAML (`.goose/recipes/*.yaml`) | Native inline (orchestrator `sub_recipes`; specialists `summon` `load`) | `team-builder.yaml` recipe |
+| `goose` **(beta)** | Recipe YAML (`.goose/recipes/*.yaml`) | Native inline (orchestrator `sub_recipes`; specialists `summon` `load`) | `team-builder.yaml` recipe |
+
+> **Goose support is in beta.** Generate, convert, and bridge are supported and validated against the Goose CLI; interop-to-Goose is not yet supported, and converting from `claude`/`copilot-cli` sources currently yields flat (un-delegated) recipes pending handoff-recovery work. The `goose` adapter API is not yet covered by the [stability policy](STABILITY.md).
 
 For `copilot-cli` and `claude`, inline handoff sections are still stripped from the emitted agent prompts. When AgentTeams extracts handoffs from the rendered source content, it preserves that routing metadata in `references/runtime-handoffs.json` so bridge layers or external tooling can consume the handoff contract without relying on VS Code-specific YAML. `goose` encodes handoffs natively inside each recipe (orchestrator → `sub_recipes`, deeper edges → `summon` `load(...)`), so it emits **no** `runtime-handoffs.json` sidecar.
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -26,6 +26,15 @@ The supported import surface is everything documented under
 - `agentteams.frameworks.{copilot_vscode, copilot_cli, claude}`
 - `build_team.main`, `build_team.__version__`
 
+> **Beta frameworks.** The `goose` and `agents-md` framework adapters
+> (`agentteams.frameworks.{goose, agents_md}`) are in **beta**: they are shipped,
+> tested, and usable, but their adapter API and emitted-artifact shapes are **not
+> yet covered by the SemVer contract above** and may change in a minor release while
+> the integration matures. For `goose` specifically, generate / convert / bridge are
+> supported (interop-to-Goose is not yet supported, and convert from `claude` /
+> `copilot-cli` sources currently yields flat, un-delegated recipes pending
+> handoff-recovery work). They graduate to the stable contract once those gaps close.
+
 Symbols not documented in `docs_src/api-reference/` are **internal** and may
 change without notice — including modules whose name starts with `_`,
 functions starting with `_`, and any helper not listed in the reference docs.

--- a/docs_src/api-reference/convert.md
+++ b/docs_src/api-reference/convert.md
@@ -58,7 +58,10 @@ Raises:
 3. Emits any adapter sidecars via `extra_output_files` — e.g. `goose`'s repo-root `.goosehints` integrator.
 4. Copies passthrough assets such as `SETUP-REQUIRED.md` and `references/`.
 
-### Goose target (`--framework goose`)
+### Goose target (`--framework goose`) — beta
+
+!!! note "Beta"
+    Goose is a **beta** convert target; its emitted-artifact shapes are not yet covered by the [stability policy](https://github.com/jlcatonjr/agentteams/blob/main/STABILITY.md).
 
 Converting an existing team to Goose emits one recipe per agent under `.goose/recipes/*.yaml`, plus the repo-root `AGENTS.md` + `.goosehints`. The orchestrator's `sub_recipes` delegation is reconstructed from each agent's handoffs:
 

--- a/docs_src/api-reference/feature-inventory.md
+++ b/docs_src/api-reference/feature-inventory.md
@@ -77,7 +77,7 @@ Use this matrix when deciding which module/artifact to rely on for a specific op
 
 Two additional first-class adapters extend this set:
 
-- **`goose` Adapter** — Block / AAIF Goose recipe YAML (`.goose/recipes/*.yaml`, schema `1.0.0`); orchestrator delegation encoded natively as `sub_recipes` (deeper edges become `summon` `load(...)`); team brief written to the repo-root `AGENTS.md` plus a `.goosehints` integrator. Also a valid `--convert-from` and `--bridge-from` **target** (not an interop target). See [`frameworks`](frameworks.md).
+- **`goose` Adapter** *(beta)* — Block / AAIF Goose recipe YAML (`.goose/recipes/*.yaml`, schema `1.0.0`); orchestrator delegation encoded natively as `sub_recipes` (deeper edges become `summon` `load(...)`); team brief written to the repo-root `AGENTS.md` plus a `.goosehints` integrator. Also a valid `--convert-from` and `--bridge-from` **target** (not an interop target). **Beta** — generate/convert/bridge supported, interop planned; adapter API not yet under the stability contract. See [`frameworks`](frameworks.md).
 - **`agents-md` Adapter** — Cross-tool **AGENTS.md** standard (AAIF / Linux Foundation); emits a single framework-neutral repo-root `AGENTS.md` (read by ~10 AI coding tools) plus per-specialist detail under `.agents/`. **Generate-only** (not a convert/interop/bridge target).
 
 ### CLI

--- a/docs_src/api-reference/frameworks.md
+++ b/docs_src/api-reference/frameworks.md
@@ -211,6 +211,9 @@ Strips VS Code YAML and inline handoff blocks, then injects Claude-compatible fr
 
 > *Source: `agentteams/frameworks/goose.py`*
 
+!!! note "Beta"
+    The `GooseAdapter` is in **beta**: generate, convert, and bridge are supported and validated against the Goose CLI, but interop-to-Goose is not yet supported and convert from `claude`/`copilot-cli` sources currently yields flat recipes. Its API and emitted-artifact shapes are **not yet covered** by the [stability policy](https://github.com/jlcatonjr/agentteams/blob/main/STABILITY.md) and may change in a minor release.
+
 Adapter for Block / AAIF Goose recipes.
 
 - **framework_id:** `'goose'`

--- a/docs_src/cli-reference.md
+++ b/docs_src/cli-reference.md
@@ -51,7 +51,7 @@ Target agent framework. Choices: `copilot-vscode` (default), `copilot-cli`, `cla
 | `copilot-vscode` | `.agent.md` with YAML front matter | VS Code Copilot agents with full handoff support |
 | `copilot-cli` | Plain `.md` | Copilot CLI system prompts; inline YAML and handoff sections stripped, with handoffs preserved in `references/runtime-handoffs.json` when present |
 | `claude` | Claude front matter `.md` | Claude Projects; output includes `CLAUDE.md` instructions and preserves handoffs in `references/runtime-handoffs.json` when present |
-| `goose` | Recipe YAML (`.goose/recipes/*.yaml`) | Block / AAIF Goose recipes; orchestrator delegates via `sub_recipes`, deeper edges become `summon` `load(...)`; team brief written to repo-root `AGENTS.md` + `.goosehints`. Handoffs are encoded natively in the recipes (no `runtime-handoffs.json` sidecar) |
+| `goose` **(beta)** | Recipe YAML (`.goose/recipes/*.yaml`) | Block / AAIF Goose recipes; orchestrator delegates via `sub_recipes`, deeper edges become `summon` `load(...)`; team brief written to repo-root `AGENTS.md` + `.goosehints`. Handoffs are encoded natively in the recipes (no `runtime-handoffs.json` sidecar). **Beta** — see the feature-support matrix below |
 | `agents-md` | Plain `.md` | Cross-tool **AGENTS.md** standard (AAIF / Linux Foundation). Emits a single framework-neutral repo-root `AGENTS.md` — the canonical file read by ~10 tools (Continue, Cursor, Cline, Codex, Zed, Aider, …) — plus per-specialist detail under `.agents/`. Routing preserved in `references/runtime-handoffs.json`. **Generate-only** (not a `--convert-from`/`--interop-from`/`--bridge-from` target). |
 
 `references/runtime-handoffs.json` is a framework-neutral sidecar manifest emitted when extracted handoffs exist for frameworks that do not keep inline VS Code handoff syntax in the final agent file.
@@ -65,10 +65,12 @@ Target agent framework. Choices: `copilot-vscode` (default), `copilot-cli`, `cla
 | `copilot-vscode` | ✓ | ✓ | ✓ | ✓ |
 | `copilot-cli` | ✓ | ✓ | ✓ | ✓ |
 | `claude` | ✓ | ✓ | ✓ | ✓ |
-| `goose` | ✓ | ✓ <sup>1</sup> | ✗ *(planned)* <sup>2</sup> | ✓ |
+| `goose` **(beta)** | ✓ | ✓ <sup>1</sup> | ✗ *(planned)* <sup>2</sup> | ✓ |
 | `agents-md` | ✓ | ✗ <sup>3</sup> | ✗ <sup>3</sup> | ✗ <sup>3</sup> |
 
 **✓** available · **✗** not a valid target (by design) · **✗ *(planned)*** not yet developed
+
+> **`goose` is in beta** — generate/convert/bridge are validated against the Goose CLI, but the integration is still maturing (interop and full delegation from `claude`/`copilot-cli` convert sources are in development) and the `goose` adapter API is not yet covered by the [stability policy](https://github.com/jlcatonjr/agentteams/blob/main/STABILITY.md).
 
 - **Generate** — `--framework X --description …` (or `--self`).
 - **Convert target** — `--convert-from <team> --framework X` (format migration).

--- a/docs_src/getting-started.md
+++ b/docs_src/getting-started.md
@@ -78,7 +78,10 @@ Framework-specific defaults:
 - `copilot-vscode` -> `/path/to/your/project/.github/agents/`
 - `copilot-cli` -> `/path/to/your/project/.github/copilot/`
 - `claude` -> `/path/to/your/project/.claude/agents/`
-- `goose` -> `/path/to/your/project/.goose/recipes/`
+- `goose` **(beta)** -> `/path/to/your/project/.goose/recipes/`
+
+!!! note "Goose is in beta"
+    The `goose` framework supports generate, convert, and bridge (interop is not yet supported) and its adapter API is not yet covered by the [stability policy](https://github.com/jlcatonjr/agentteams/blob/main/STABILITY.md). See the [feature-support matrix](cli-reference.md#feature-support-by-framework).
 
 Instructions file defaults:
 

--- a/docs_src/how-it-works.md
+++ b/docs_src/how-it-works.md
@@ -170,9 +170,9 @@ The same template library targets four frameworks via adapters in `agentteams/fr
 | `copilot-vscode` | `.agent.md` with YAML front matter | VS Code Copilot agent panel |
 | `copilot-cli` | Plain `.md` system prompts | `gh copilot` CLI |
 | `claude` | Claude front matter `.md` + `CLAUDE.md` | Claude Projects |
-| `goose` | Recipe YAML (`.goose/recipes/*.yaml`) + repo-root `AGENTS.md`/`.goosehints` | `goose run --recipe` |
+| `goose` **(beta)** | Recipe YAML (`.goose/recipes/*.yaml`) + repo-root `AGENTS.md`/`.goosehints` | `goose run --recipe` |
 
-Each adapter in `agentteams/frameworks/` knows the file naming conventions, front-matter schema, and handoff delivery mode for its target framework. VS Code Copilot keeps handoffs inline; frameworks that do not support the VS Code syntax can instead receive a sidecar `references/runtime-handoffs.json` manifest when extracted handoffs are present. Goose encodes handoffs natively inside each recipe (orchestrator `sub_recipes`; deeper edges become `summon` `load(...)`), so it emits no sidecar.
+Each adapter in `agentteams/frameworks/` knows the file naming conventions, front-matter schema, and handoff delivery mode for its target framework. VS Code Copilot keeps handoffs inline; frameworks that do not support the VS Code syntax can instead receive a sidecar `references/runtime-handoffs.json` manifest when extracted handoffs are present. Goose encodes handoffs natively inside each recipe (orchestrator `sub_recipes`; deeper edges become `summon` `load(...)`), so it emits no sidecar. **Goose support is in beta** (generate/convert/bridge; interop is not yet supported) and its adapter API is not yet under the [stability policy](https://github.com/jlcatonjr/agentteams/blob/main/STABILITY.md).
 
 ---
 

--- a/docs_src/index.md
+++ b/docs_src/index.md
@@ -56,12 +56,15 @@ Short reads (about five paragraphs each) explaining how core module components f
 | `copilot-vscode` | `.agent.md` with YAML front matter | Native inline YAML | VS Code Copilot `.agent.md` |
 | `copilot-cli` | Plain `.md` system prompts | Runtime manifest when handoffs are present (`references/runtime-handoffs.json`) | CLI prompt `.md` |
 | `claude` | Claude front matter `.md` + `CLAUDE.md` instructions | Runtime manifest when handoffs are present (`references/runtime-handoffs.json`) | `CLAUDE.md` system prompt |
-| `goose` | Block / AAIF Goose recipe YAML (`.goose/recipes/*.yaml`) | Native — orchestrator handoffs become `sub_recipes`, deeper edges become `summon` `load(...)` (no sidecar) | Runnable `team-builder.yaml` recipe |
+| `goose` **(beta)** | Block / AAIF Goose recipe YAML (`.goose/recipes/*.yaml`) | Native — orchestrator handoffs become `sub_recipes`, deeper edges become `summon` `load(...)` (no sidecar) | Runnable `team-builder.yaml` recipe |
 | `agents-md` | Cross-tool **AGENTS.md** standard (plain `.md`) | Routing preserved in `references/runtime-handoffs.json` | `.agents/team-builder.md` |
 
 For `copilot-cli`, `claude`, and `agents-md`, AgentTeams strips inline handoff sections from the visible prompt files but emits `references/runtime-handoffs.json` when handoffs are extracted, so routing metadata remains available to bridge layers and other runtime tooling. `copilot-vscode` and `goose` keep handoff semantics inline (for Goose, encoded directly in the recipes).
 
-**Goose** (`--framework goose`) emits one recipe per agent plus a team brief at the repo-root `AGENTS.md` and a `.goosehints` integrator; the orchestrator delegates to specialist recipes via `sub_recipes`. It is supported for **generate**, **convert** (`--convert-from … --framework goose`), and **bridge** (`--bridge-from … --framework goose`); **interop-to-Goose is not yet supported** (the canonical interop representation drops the handoff graph — use `--convert-from`). See the [framework feature-support matrix](cli-reference.md#feature-support-by-framework).
+!!! note "Goose support is in beta"
+    Goose support works and is validated against the Goose CLI, but is still maturing: **interop-to-Goose is not yet supported**, converting from `claude`/`copilot-cli` sources currently yields flat (un-delegated) recipes, and the `goose` adapter API is **not yet covered by the [stability policy](https://github.com/jlcatonjr/agentteams/blob/main/STABILITY.md)** (it may change in a minor release). See the [framework feature-support matrix](cli-reference.md#feature-support-by-framework).
+
+**Goose** (`--framework goose`) emits one recipe per agent plus a team brief at the repo-root `AGENTS.md` and a `.goosehints` integrator; the orchestrator delegates to specialist recipes via `sub_recipes`. It is supported for **generate**, **convert** (`--convert-from … --framework goose`), and **bridge** (`--bridge-from … --framework goose`); interop-to-Goose is planned (the canonical interop representation drops the handoff graph — use `--convert-from`).
 
 **`agents-md`** (`--framework agents-md`) emits a single framework-neutral repo-root `AGENTS.md` — the canonical file read by ~10 AI coding tools (Continue, Cursor, Cline, Codex, Zed, Aider, …) — plus per-specialist detail under `.agents/`. It is **generate-only**.
 


### PR DESCRIPTION
Indicates Goose's **beta** development phase across all relevant docs.

**Why beta (not alpha):** generate / convert / bridge are validated against the real Goose CLI with passing tests (so it's past experimental/alpha), but the `goose` adapter API isn't frozen — STABILITY.md §2 covers only `copilot_vscode`/`copilot_cli`/`claude` — and there are gaps (interop-to-Goose unsupported; convert from `claude`/`copilot-cli` yields flat recipes). That's the textbook beta state.

**Where it's marked (10 files):**
- **STABILITY.md** — canonical note that the `goose`/`agents_md` adapters are beta and explicitly **not yet under the SemVer contract**.
- **README.md**, **docs_src/index.md**, **cli-reference.md**, **how-it-works.md**, **getting-started.md** — `(beta)` on the goose framework-table rows + a beta admonition/note linking the stability policy and the feature-support matrix.
- **api-reference**: `frameworks.md` (GooseAdapter), `convert.md` (goose target), `feature-inventory.md` (goose adapter) — beta admonitions.
- **CHANGELOG.md** — Goose `[Unreleased]` entry marked `(beta)`.

Docs-only; mkdocs builds clean (no new warnings; the `changelog→STABILITY` warning is pre-existing); doc-structure / root-hygiene / RSR1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)