### PR TITLE
docs(worksummary): 2026-06-16 capture — live test of CI/CD verification

### DIFF
--- a/workSummaries/daily/2026-06-16.md
+++ b/workSummaries/daily/2026-06-16.md
@@ -1,0 +1,46 @@
+# Daily Work Summary — 2026-06-16
+
+## Session: Goose representation/beta + CI/CD deployment-verification feature
+
+**Trigger:** A sequence of user requests: represent the Goose integration across the docs/API/entry page, mark Goose support as beta, add a generative-infrastructure requirement that generated teams verify post-merge CI/CD deployment succeeds, then dogfood that feature on the repo's own team.
+
+**Plans (retained):** `references/plans/cicd-deployment-verification-2026-06-16.plan.md` (+ the goose/agents-md and module-split plans under `references/plans/`).
+
+---
+
+## Completed Work
+
+### Goose representation + beta status (PRs #28–#31)
+
+- **Framework feature-support matrix** added to `docs_src/cli-reference.md` (Generate / Convert / Interop / Bridge per framework; goose interop marked *planned*). — PR #28
+- **Goose represented across the API reference** (`convert.md`, `interop.md`, `frameworks.md`, `feature-inventory.md`) and the **docs entry page** (`docs_src/index.md`). — PRs #29, #30
+- **Goose marked beta** across all relevant docs (STABILITY.md, README, index, cli-reference, how-it-works, getting-started, api-reference, CHANGELOG), anchored to STABILITY.md (the `goose`/`agents_md` adapters are explicitly not yet under the SemVer contract). Decision recorded: **beta, not alpha** — generate/convert/bridge are validated against the real Goose CLI with passing tests, but interop is missing and the adapter API is not frozen. — PR #31
+
+### CI/CD post-merge deployment verification — generative infrastructure (PR #32)
+
+Generated teams now verify that the CI/CD runs a push/merge **triggers** (CI + deployment workflows) reach `conclusion == success`, distinct from the pre-merge required status checks that gate the merge.
+
+- `git-operations.template.md` — new Invariant Core **rule 7** + an Output-Contract CI/CD-status line (conditional; skip when no push/merge or no workflows; fix-until-green via `gh run view --log-failed`; cross-repo re-push re-enters Rule 11). Owner: `@git-operations`.
+- `github-workflows-merge.reference.template.md` — new **"Post-Merge / Post-Push CI/CD Deployment Verification"** section + a parallel audit-log bullet.
+- `orchestrator.template.md` — a conditional **closeout-gate step in Workflow 11: Final Check**, placed *inside* the `available_workflows` fence so it propagates to existing teams on `--update --merge`.
+- Regenerated the 4 example snapshots (only the 3 intended files each); added `tests/test_cicd_deployment_verification.py` (3 tests).
+
+**Audit:** each plan passed adversarial + conflict audits (auditors prototyped + regenerated snapshots). The audit caught that the orchestrator Constitutional Rules block is USER-EDITABLE/non-fenced — a "Rule 16" would not propagate — so the tie-in was moved to the fenced Workflow 11.
+
+### Self-team update + live feature test
+
+- Ran `build_team.py --self --update --merge --shrink-policy=halt` against the repo's own (gitignored) `.github/agents/` team. **Propagation verified:** the new git-operations invariant, Output-Contract line, reference section, and the *fenced* orchestrator Workflow-11 closeout gate all reached the existing team via merge — confirming the fenced-propagation design.
+- The self-team is gitignored (by design, per STABILITY.md), so the self-update has nothing to commit; this work summary (Rule 12) is the committed artifact whose push/merge exercises the new CI/CD deployment-verification rule end-to-end.
+
+---
+
+## Verification
+
+- Full suite **1389 passed** at the CI/CD-feature merge; all PRs CI-green on all four jobs.
+- Each merge's **post-merge triggered runs verified `success`** (CI + Deploy Docs) — the new rule applied to its own delivery.
+- Live docs (`https://jlcatonjr.github.io/agentteams/`) confirmed serving the goose representation + beta markers.
+
+## Open / next
+
+- **Goose handoff recovery (#2/#3)** — audited, implementation-ready plan (`references/plans/closeout-23-goose-handoff-recovery-2026-06-15.plan.md`); awaiting go-ahead. Would enable interop-to-Goose and full delegation from `claude`/`copilot-cli` convert sources.
+- Deferred: getting `emit.py`/`analyze.py` under the 1000-line ceiling (second carve each).


### PR DESCRIPTION
**Live test of the post-merge CI/CD deployment-verification feature** (PR #32).

The repo's own `.github/agents/` team and `workSummaries/` are both gitignored, so the self-team update that propagated the new rule has nothing to commit by default. This Rule-12 daily summary (force-added to match the 4 existing tracked summaries) is the legitimate artifact whose merge exercises the feature: after merge I verify the triggered runs (CI + Deploy Docs) reach `success`, exactly as the new `@git-operations` invariant + orchestrator Workflow-11 closeout gate require.

*Revert note:* if milestone summaries should stay local, this is trivially revertable (the dir is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)