### PR TITLE
docs(worksummary): append work-summarizer remediation to 2026-06-16

### DIFF
--- a/workSummaries/daily/2026-06-16.md
+++ b/workSummaries/daily/2026-06-16.md
@@ -40,6 +40,27 @@ Generated teams now verify that the CI/CD runs a push/merge **triggers** (CI + d
 - Each merge's **post-merge triggered runs verified `success`** (CI + Deploy Docs) — the new rule applied to its own delivery.
 - Live docs (`https://jlcatonjr.github.io/agentteams/`) confirmed serving the goose representation + beta markers.
 
+### @work-summarizer reliable-trigger remediation (PR #34)
+
+Investigated why `@work-summarizer` wasn't firing reliably and remediated the generative
+infrastructure. Root cause (adversarial+conflict audited; two of my initial claims were
+corrected): the daily capture was a **soft step buried at the tail of Workflow 11**,
+reachable only via the numbered-workflow chain, so ad-hoc/direct executed-work sessions
+closed without it. Fix (all inside the **fenced** `available_workflows`, so it propagates on
+`--update --merge`): promoted the daily capture to a **blocking closeout gate** (parity with
+security/hygiene/CI-CD), conditional on executed work, run as the terminal act after the CI/CD
+gate; made Workflow 11 reachable for **any** executed-work session (closes the ad-hoc bypass);
+made `@work-summarizer` explicitly git-first. New `tests/test_work_summary_gate.py` (6).
+**Initial test:** `--self --update --merge` propagated the new blocking gate into this repo's
+own already-deployed team (before: 0 markers → after: all 5, gate confirmed inside the fence).
+Post-merge deployment verified (Deploy Docs + CI `success`).
+
+### Branch hygiene
+
+Reviewed all 11 local branches; pushed the one safe fast-forward (`refactor/code-hygiene`,
+already-merged work) and pruned 3 merged + remote-deleted local branches. Left `gh-pages`
+untouched (CI-managed; local copy 2 months stale — pushing would have reverted the live site).
+
 ## Open / next
 
 - **Goose handoff recovery (#2/#3)** — audited, implementation-ready plan (`references/plans/closeout-23-goose-handoff-recovery-2026-06-15.plan.md`); awaiting go-ahead. Would enable interop-to-Goose and full delegation from `claude`/`copilot-cli` convert sources.


### PR DESCRIPTION
Appends this session's work-summarizer reliable-trigger fix (PR #34) + branch hygiene to today's daily summary, per the now-blocking work-summary closeout gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)