### PR TITLE
feat: stale doc/script detector + remediator (+ land in-flight vscode-tasks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### added
 
+- **Stale detector/remediator (`--stale-check`).** Additive minor change (new flags +
+  the exit-3 contract enter the SemVer surface per `STABILITY.md`). A standalone,
+  read-only scan of `--output`/`--project` (else CWD) that reports stale agent docs and
+  code/scripts across reliability tiers:
+  - **Tier-1 (blocking, exit 1):** `VCS_CONFLICT_MARKER` (a complete, ordered git
+    merge-conflict triad, fenced-code and setext-underline aware), `BROKEN_REF` (a
+    markdown-link target absent on disk), and provenance-gated `INTEGRITY` (reuses
+    `drift.verify_output_integrity` for every discovered `references/build-log.json`)
+    and `SOURCE_DRIFT` (bridge source divergence, gated on source presence).
+  - **Tier-2 (advisory):** `STALE_VS_CODE` — git-recency: referenced code committed in a
+    commit strictly *after* the doc's last commit, with a substantive (whitespace-filtered)
+    diff. Self-disables on non-git/shallow repos and skips uncommitted paths.
+  - **Tier-0 (INFO):** `PROVENANCE_ABSENT`, `BRIDGE_SOURCE_UNAVAILABLE` (a consumer repo
+    whose bridge `source_dir` is not present on this machine).
+  - The file set comes from `git ls-files` in a work-tree (excludes gitignored `tmp/`,
+    backups, local `references/plans/`) plus an explicit `examples/` fixture skip.
+  - `--stale-remediate` prints a **guided remediation plan**; adding `--yes` promotes it
+    into an **applied, backup-protected revision pass**: it takes a sha256-verified safety
+    snapshot of every file it will touch into `.agentteams-backups/stale-fix-<ts>/` BEFORE
+    writing, then performs only safe deterministic revisions — broken-reference repair
+    (relocating a link to a moved file, never inside a fenced/USER-EDITABLE region) and
+    bridge re-merge for `SOURCE_DRIFT` (the canonical fence-aware writer). `INTEGRITY` is
+    routed (the exact `--update --merge` command is printed, not auto-run); conflict markers
+    are never auto-resolved. Exit 3 when blocking items remain after an apply.
+  - `--stale-restore [TS]` recovers files from a stale-fix snapshot (default: latest),
+    verifying each backup's sha256 before writing — the recovery path for a revision that
+    went wrong. `--stale-no-git` skips the Tier-2 git-recency signal. The man page documents
+    exit 1/2/3. Methods report, plan, and adversarial+conflict audits under
+    `references/plans/stale-detector-*`.
+  - **`.agentteams-stale-ignore`** (gitignore-style file at the scan root) suppresses
+    known-acceptable findings — cross-repo links, captured/read-only packages, archival
+    docs. Matches the referrer file or (for a broken ref) the target; supports exact paths,
+    directory prefixes, and `*` globs. **Never suppresses `VCS_CONFLICT_MARKER`.** Suppressed
+    findings are counted (`suppressed: N`), never silent; note suppression can flip a Tier-1
+    exit `1` to `0`. (Evolvable input config, not a frozen format.)
+  - The revision phase now **warns** when a safety snapshot is written into a repo where
+    `.agentteams-backups/` is not gitignored (it never auto-edits `.gitignore`).
+  - The write/revision phase moved to a new module `agentteams/stale_remediate.py`
+    (`stale_detector.py` stays detection-only — CH-07 module-size discipline).
+
 - **Goose (Block / AAIF) framework support (beta).** Adds Goose as a target
   alongside Copilot and Claude. **Beta:** generate/convert/bridge are supported and
   validated against the Goose CLI; interop-to-Goose is not yet supported and the

--- a/agentteams.1
+++ b/agentteams.1
@@ -2,7 +2,7 @@
 .SH NAME
 agentteams \- Generate a complete agent team for any project.
 .SH SYNOPSIS
-.B agentteams [--description PATH] [--project PATH] [--framework NAME] [--output DIR] [--dry-run] [--json] [--overwrite] [--merge] [--yes] [--no-scan] [--cost-routing] [--update] [--prune] [--adopt-orphans] [--check] [--refresh-index] [--query-index TEXT] [--query-k N] [--query-strategy QUERY_STRATEGY] [--fail-on-legacy-skip] [--no-add-fence-markers] [--scan-security] [--check-budget] [--self] [--allow-external-self-output] [--post-audit] [--auto-correct] [--enrich] [--strict-manual-placeholders] [--no-strict-manual-placeholders STRICT_MANUAL_PLACEHOLDERS] [--security-offline] [--security-max-items N] [--security-no-nvd] [--migrate] [--convert-from DIR] [--interop-from DIR] [--interop-source-framework INTEROP_SOURCE_FRAMEWORK] [--interop-mode INTEROP_MODE] [--bridge-from DIR] [--bridge-source-framework BRIDGE_SOURCE_FRAMEWORK] [--bridge-check] [--bridge-refresh] [--bridge-merge] [--bridge-no-skills] [--recipe-check] [--revert-migration] [--version] [--no-backup] [--shrink-policy SHRINK_POLICY] [--list-backups] [--restore-backup TIMESTAMP] [--add-fence-markers PATH] [--in-place] [--target-host-features TOKENS] [--capture-baseline PATH] [--baseline-label LABEL] [--check-baseline PATH] [--verify-waivers] [--verify-integrity] [--verify-backup TIMESTAMP] [--prune-backups KEEP] [--keep-within-days DAYS] [--backup-mirror DIR] [--fleet DIR] [--fleet-frameworks FLEET_FRAMEWORKS] [--fleet-report DIR]
+.B agentteams [--description PATH] [--project PATH] [--framework NAME] [--output DIR] [--dry-run] [--json] [--overwrite] [--merge] [--yes] [--no-scan] [--cost-routing] [--update] [--prune] [--adopt-orphans] [--check] [--refresh-index] [--query-index TEXT] [--query-k N] [--query-strategy QUERY_STRATEGY] [--fail-on-legacy-skip] [--no-vscode-tasks] [--no-add-fence-markers] [--scan-security] [--check-budget] [--self] [--allow-external-self-output] [--post-audit] [--auto-correct] [--enrich] [--strict-manual-placeholders] [--no-strict-manual-placeholders STRICT_MANUAL_PLACEHOLDERS] [--security-offline] [--security-max-items N] [--security-no-nvd] [--migrate] [--convert-from DIR] [--interop-from DIR] [--interop-source-framework INTEROP_SOURCE_FRAMEWORK] [--interop-mode INTEROP_MODE] [--bridge-from DIR] [--bridge-source-framework BRIDGE_SOURCE_FRAMEWORK] [--bridge-check] [--bridge-refresh] [--bridge-merge] [--bridge-no-skills] [--recipe-check] [--revert-migration] [--version] [--no-backup] [--shrink-policy SHRINK_POLICY] [--list-backups] [--restore-backup TIMESTAMP] [--add-fence-markers PATH] [--in-place] [--target-host-features TOKENS] [--capture-baseline PATH] [--baseline-label LABEL] [--check-baseline PATH] [--verify-waivers] [--verify-integrity] [--verify-backup TIMESTAMP] [--stale-check] [--stale-remediate] [--stale-no-git] [--stale-restore TS] [--prune-backups KEEP] [--keep-within-days DAYS] [--backup-mirror DIR] [--fleet DIR] [--fleet-frameworks FLEET_FRAMEWORKS] [--fleet-report DIR]
 .SH DESCRIPTION
 .PP
 Generate a complete agent team for any project.
@@ -71,6 +71,9 @@ Query strategy for \-\-query\-index: 'lexical' (BM25, default) or 'vector' (cosi
 .TP
 .B \-\-fail\-on\-legacy\-skip
 Exit with non\-zero status if \-\-merge skipped any files due to missing fence markers (legacy files). Use in CI to enforce that template updates always propagate to downstream repositories.
+.TP
+.B \-\-no\-vscode\-tasks
+Suppress generation of .vscode/tasks.json. By default, agentteams emits a tasks.json at the project root containing discovered project commands (npm scripts, Makefile PHONY targets, etc.) and agentteams meta\-tasks. Pass this flag for repositories that manage tasks.json manually.
 .TP
 .B \-\-no\-add\-fence\-markers
 Opt OUT of the default behaviour where \-\-update \-\-merge (with \-\-yes) auto\-retrofits AGENTTEAMS `content` fence markers onto legacy (unfenced) files so their template region becomes mergeable instead of being skipped. Each retrofit is backed up first and the shrink\-guard still suppresses material template shrinks, so the legacy body is recoverable. Pass this flag to keep the conservative skip\-legacy behaviour (distinct from the standalone per\-file `\-\-add\-fence\-markers PATH` retrofit).
@@ -192,6 +195,18 @@ Read\-only: classify every generated output file under \-\-output/\-\-project (e
 .B \-\-verify\-backup TIMESTAMP
 Read\-only: verify a backup is restorable — its bytes match the recorded source_sha256 in _manifest.json. Defaults to the latest backup; pass a TIMESTAMP for a specific one. Exits non\-zero on any bit\-rot/tamper mismatch.
 .TP
+.B \-\-stale\-check
+Read\-only: scan \-\-output/\-\-project (else CWD) for stale agent docs and code/scripts (VCS conflict markers, broken references, git\-recency divergence, provenance\-gated generated\-file integrity). Exits non\-zero on any Tier\-1 (blocking) finding. Never edits files.
+.TP
+.B \-\-stale\-remediate
+Modifier for \-\-stale\-check: also print a guided remediation plan (suggestions only; does NOT edit files, unlike \-\-auto\-correct).
+.TP
+.B \-\-stale\-no\-git
+Modifier for \-\-stale\-check: skip the Tier\-2 git\-recency signal (hermetic/CI or non\-git targets).
+.TP
+.B \-\-stale\-restore TS
+Standalone: restore files from a \-\-stale\-remediate \-\-yes safety snapshot (.agentteams\-backups/stale\-fix\-<TS>/; default: latest). Recovery path for a revision that went wrong.
+.TP
 .B \-\-prune\-backups KEEP
 Standalone: delete old timestamped backups under \-\-output/\-\-project (else CWD) .agentteams\-backups/, keeping the newest KEEP (default 10). The single newest backup is NEVER deleted, even with KEEP 0. Combine with \-\-keep\-within\-days to also retain anything younger than N days, and \-\-dry\-run to preview. This bounds backup growth; distinct from \-\-prune (which removes stale *agents*, not backups).
 .TP
@@ -215,7 +230,13 @@ Directory for the fleet report (default: <DIR>/.agentteams\-fleet/<run\-id>/).
 Success.
 .TP
 .B 1
-Error: validation failure, file not found, drift detected (with \fB--check\fR), or security issues (with \fB--scan-security\fR).
+Error: validation failure, file not found, drift detected (with \fB--check\fR), security issues (with \fB--scan-security\fR), or a Tier-1 (blocking) finding (with \fB--stale-check\fR).
+.TP
+.B 2
+Baseline drift detected (with \fB--check-baseline\fR).
+.TP
+.B 3
+Reserved: remediation attempted but unresolved (with \fB--stale-check --stale-remediate\fR).
 .SH EXAMPLES
 .PP
 Generate a VS Code Copilot agent team:

--- a/agentteams/cli/app.py
+++ b/agentteams/cli/app.py
@@ -21,6 +21,8 @@ from agentteams.cli.commands import (
     _run_convert,
     _run_interop,
     _run_prune_backups,
+    _run_stale_check,
+    _run_stale_restore,
     _run_verify_backup,
     _run_verify_integrity,
     _run_verify_waivers,
@@ -142,6 +144,19 @@ def main(argv: list[str] | None = None) -> int:
     # -----------------------------------------------------------------------
     if getattr(args, "prune_backups", None) is not None:
         return _run_prune_backups(args)
+
+    # -----------------------------------------------------------------------
+    # --stale-check: standalone read-only staleness scan (docs + code/scripts).
+    # The exit code IS the verdict (0 clean / 1 blocking). Never edits files.
+    # -----------------------------------------------------------------------
+    if getattr(args, "stale_check", False):
+        return _run_stale_check(args)
+
+    # -----------------------------------------------------------------------
+    # --stale-restore: recover files from a --stale-remediate --yes snapshot.
+    # -----------------------------------------------------------------------
+    if getattr(args, "stale_restore", None) is not None:
+        return _run_stale_restore(args)
 
     # -----------------------------------------------------------------------
     # --add-fence-markers: standalone file-retrofit (no description needed).

--- a/agentteams/cli/commands.py
+++ b/agentteams/cli/commands.py
@@ -111,6 +111,70 @@ def _run_verify_integrity(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_stale_check(args: argparse.Namespace) -> int:
+    """``--stale-check``: read-only staleness scan of the resolved scan root.
+
+    Resolves the scan root from ``--output``/``--project`` (else CWD), walks down it
+    (auto-discovering generation provenance beneath), and reports stale agent docs and
+    code/scripts across reliability tiers. Exit 1 on any Tier-1 (blocking) finding; 0
+    otherwise. Never edits files. With ``--stale-remediate`` it also prints a guided
+    (suggestion-only) remediation plan.
+    """
+    from agentteams import stale_detector
+
+    root = _resolve_output_dir(args)
+    if not root.exists():
+        print(f"Error: stale-check target does not exist: {root}", file=sys.stderr)
+        return 1
+    try:
+        report = stale_detector.scan_staleness(
+            root, include_git=not bool(getattr(args, "stale_no_git", False))
+        )
+    except (OSError, ValueError) as exc:
+        # CH-24: read-only CLI boundary — surface, don't traceback.
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    stale_detector.print_staleness_report(report)
+    if bool(getattr(args, "stale_remediate", False)):
+        # --yes promotes the preview into an applied, snapshot-protected revision pass.
+        from agentteams import stale_remediate
+        apply = bool(getattr(args, "yes", False))
+        result = stale_remediate.apply_fixes(report, root, apply=apply)
+        stale_remediate.print_fix_result(result)
+        if apply:
+            # exit 3 = remediation attempted but blocking items remain (manual/routed).
+            return 3 if result.n_unresolved > 0 else 0
+    return stale_detector.exit_code(report)
+
+
+def _run_stale_restore(args: argparse.Namespace) -> int:
+    """``--stale-restore [TS]``: recover files from a --stale-remediate safety snapshot
+    under .agentteams-backups/stale-fix-<TS>/ (default: the latest). The recovery path
+    for a revision that went wrong; verifies each backup's sha256 before writing."""
+    from agentteams import stale_remediate
+
+    root = _resolve_output_dir(args)
+    ts = getattr(args, "stale_restore", None)
+    if ts in (None, "latest"):
+        snap = stale_remediate.latest_snapshot(root)
+    else:
+        cand = root / ".agentteams-backups" / f"stale-fix-{ts}"
+        snap = cand if cand.is_dir() else None
+    if snap is None:
+        print(f"Error: no stale-fix snapshot found under {root}/.agentteams-backups/",
+              file=sys.stderr)
+        return 1
+    try:
+        restored = stale_remediate.restore_snapshot(root, snap)
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Restored {len(restored)} file(s) from {snap}:")
+    for rel in restored:
+        print(f"  {rel}")
+    return 0
+
+
 def _run_verify_backup(args: argparse.Namespace) -> int:
     """``--verify-backup [TS]``: read-only check that a backup is restorable — its
     bytes match the recorded ``source_sha256`` in ``_manifest.json``. Exit 1 on any

--- a/agentteams/cli/generate.py
+++ b/agentteams/cli/generate.py
@@ -95,6 +95,7 @@ def run_generate(args: argparse.Namespace, strict_manual_placeholders: bool) -> 
     manifest["host_features"] = list(getattr(args, "host_features", []) or [])
     if manifest["host_features"]:
         print(f"  Host features: {', '.join(manifest['host_features'])}")
+    manifest["no_vscode_tasks"] = bool(getattr(args, "no_vscode_tasks", False))
 
     project_name = manifest["project_name"]
     project_type = manifest["project_type"]
@@ -357,7 +358,7 @@ def run_generate(args: argparse.Namespace, strict_manual_placeholders: bool) -> 
 
     # Apply framework-specific post-processing; runtime-handoffs and pipeline
     # graph (Step 5c) are appended by _build_final_rendered.
-    final_rendered = _build_final_rendered(manifest, adapter, project_name)
+    final_rendered = _build_final_rendered(manifest, adapter, project_name, output_dir=output_dir)
 
     # -----------------------------------------------------------------------
     # Step 5b: Handle --update (structural + content drift, manual preservation)
@@ -495,6 +496,17 @@ def run_generate(args: argparse.Namespace, strict_manual_placeholders: bool) -> 
                     existing_path.read_text(encoding="utf-8"), content
                 )
             update_rendered.append((rel_path, content))
+
+        # Sidecar files (e.g. .vscode/tasks.json) are not tracked by the
+        # structural drift detector and are therefore absent from update_paths.
+        # Include them whenever their rendered content differs from disk.
+        _already_included = {p for p, _ in update_rendered}
+        for _sc_path, _sc_content in final_rendered:
+            if _sc_path in _already_included or _sc_path in update_paths:
+                continue
+            _sc_disk = emit._resolve_path(output_dir, _sc_path)
+            if not _sc_disk.exists() or _sc_disk.read_text(encoding="utf-8") != _sc_content:
+                update_rendered.append((_sc_path, _sc_content))
 
         # Migrate away legacy tool-*.agent.md files: tools are now emitted as
         # reference/skill documents, never agents. Runs before the converged

--- a/agentteams/cli/parser.py
+++ b/agentteams/cli/parser.py
@@ -180,6 +180,18 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--no-vscode-tasks",
+        action="store_true",
+        dest="no_vscode_tasks",
+        help=(
+            "Suppress generation of .vscode/tasks.json. By default, agentteams "
+            "emits a tasks.json at the project root containing discovered project "
+            "commands (npm scripts, Makefile PHONY targets, etc.) and agentteams "
+            "meta-tasks. Pass this flag for repositories that manage tasks.json "
+            "manually."
+        ),
+    )
+    parser.add_argument(
         "--no-add-fence-markers",
         action="store_true",
         dest="no_add_fence_markers",
@@ -584,6 +596,30 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--stale-check", action="store_true", dest="stale_check", default=False,
+        help="Read-only: scan --output/--project (else CWD) for stale agent docs and "
+             "code/scripts (VCS conflict markers, broken references, git-recency "
+             "divergence, provenance-gated generated-file integrity). Exits non-zero "
+             "on any Tier-1 (blocking) finding. Never edits files.",
+    )
+    parser.add_argument(
+        "--stale-remediate", action="store_true", dest="stale_remediate", default=False,
+        help="Modifier for --stale-check: also print a guided remediation plan "
+             "(suggestions only; does NOT edit files, unlike --auto-correct).",
+    )
+    parser.add_argument(
+        "--stale-no-git", action="store_true", dest="stale_no_git", default=False,
+        help="Modifier for --stale-check: skip the Tier-2 git-recency signal "
+             "(hermetic/CI or non-git targets).",
+    )
+    parser.add_argument(
+        "--stale-restore", nargs="?", const="latest", default=None, metavar="TS",
+        dest="stale_restore",
+        help="Standalone: restore files from a --stale-remediate --yes safety snapshot "
+             "(.agentteams-backups/stale-fix-<TS>/; default: latest). Recovery path for a "
+             "revision that went wrong.",
+    )
+    parser.add_argument(
         "--prune-backups",
         nargs="?",
         type=int,
@@ -685,13 +721,21 @@ def _validate_option_combinations(parser: argparse.ArgumentParser, args: argpars
         ("--verify-integrity", bool(getattr(args, "verify_integrity", False))),
         ("--verify-backup", getattr(args, "verify_backup", None) is not None),
         ("--prune-backups", getattr(args, "prune_backups", None) is not None),
+        ("--stale-check", bool(getattr(args, "stale_check", False))),
+        ("--stale-restore", getattr(args, "stale_restore", None) is not None),
     ]
     _active_ops = [flag for flag, on in _standalone_ops if on]
     if len(_active_ops) > 1:
         parser.error(
             f"{' and '.join(_active_ops)} are mutually exclusive "
-            "(each is a standalone integrity/retention operation)"
+            "(each is a standalone, dispatch-shadowing integrity/retention operation)"
         )
+
+    # --stale-remediate / --stale-no-git are modifiers for --stale-check.
+    if getattr(args, "stale_remediate", False) and not getattr(args, "stale_check", False):
+        parser.error("--stale-remediate requires --stale-check")
+    if getattr(args, "stale_no_git", False) and not getattr(args, "stale_check", False):
+        parser.error("--stale-no-git requires --stale-check")
 
     # --keep-within-days is a modifier for --prune-backups; alone it does nothing.
     if (
@@ -722,6 +766,7 @@ def _validate_option_combinations(parser: argparse.ArgumentParser, args: argpars
             ("project", "--project"), ("output", "--output"),
             ("add_fence_markers", "--add-fence-markers"),
             ("capture_baseline", "--capture-baseline"), ("check_baseline", "--check-baseline"),
+            ("stale_check", "--stale-check"),
         ]
         for attr, flag in _fleet_incompatible:
             val = getattr(args, attr, None)

--- a/agentteams/cli/render_pipeline.py
+++ b/agentteams/cli/render_pipeline.py
@@ -15,8 +15,9 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
-from agentteams import emit, render
+from agentteams import emit, render, vscode_tasks
 from agentteams.frameworks.agents_md import AgentsMdAdapter
+from agentteams.frameworks.base import FrameworkAdapter
 from agentteams.frameworks.claude import ClaudeAdapter
 from agentteams.frameworks.copilot_cli import CopilotCLIAdapter
 from agentteams.frameworks.copilot_vscode import CopilotVSCodeAdapter
@@ -72,10 +73,50 @@ def _resolve_strict_manual_mode(*, strict_arg: bool | None, self_update: bool) -
     if strict_arg is not None:
         return bool(strict_arg)
     return bool(self_update)
+def _emit_vscode_tasks(
+    manifest: dict[str, Any],
+    adapter: FrameworkAdapter,
+    output_dir: Path | None,
+) -> tuple[str, str] | None:
+    """Return (rel_path, content) for .vscode/tasks.json, or None if disabled.
+
+    Sentinel-merges with any existing file so user-authored tasks are preserved.
+    Raises ValueError (surfaced to stderr) if the existing JSON is malformed.
+    """
+    rel_path = adapter.vscode_tasks_rel_path()
+    if rel_path is None:
+        return None
+    if manifest.get("no_vscode_tasks"):
+        return None
+
+    if output_dir is not None:
+        # resolved = <project_root>/.vscode/tasks.json — parent.parent is the project root.
+        resolved = (output_dir / rel_path).resolve()
+        project_root = resolved.parent.parent
+        existing_path: Path | None = resolved
+    else:
+        project_root = None
+        existing_path = None
+
+    commands = vscode_tasks.discover_project_commands(project_root) if project_root is not None else []
+    content = vscode_tasks.render_tasks_json(commands)
+
+    if existing_path is not None:
+        try:
+            content = vscode_tasks.sentinel_merge(existing_path, content)
+        except ValueError as exc:
+            print(f"  !  {exc}", file=sys.stderr)
+            return None
+
+    return (rel_path, content)
+
+
 def _build_final_rendered(
     manifest: dict[str, Any],
     adapter: CopilotVSCodeAdapter | CopilotCLIAdapter | ClaudeAdapter | GooseAdapter | AgentsMdAdapter,
     project_name: str,
+    *,
+    output_dir: Path | None = None,
 ) -> list[tuple[str, str]]:
     """Render templates and apply framework post-processing.
 
@@ -115,6 +156,11 @@ def _build_final_rendered(
     # (e.g. Goose's .goosehints integrator). Default is none.
     for extra_path, extra_content in adapter.extra_output_files(manifest):
         final.append((extra_path, extra_content))
+
+    # Centralized .vscode/tasks.json generation for frameworks that opt in.
+    tasks_result = _emit_vscode_tasks(manifest, adapter, output_dir)
+    if tasks_result is not None:
+        final.append(tasks_result)
 
     if runtime_handoff_agents:
         final.append((

--- a/agentteams/emit.py
+++ b/agentteams/emit.py
@@ -174,6 +174,9 @@ _YAML_FM_RE = re.compile(r"^(---\n.+?\n---\n)", re.DOTALL)
 
 _MACHINE_MANAGED_MERGE_OVERWRITE_PATHS: frozenset[str] = frozenset([
     "references/security-vulnerability-watch.json",
+    # Sentinel-merge handled in vscode_tasks.py before this path reaches emit;
+    # emit must overwrite (not fence-merge) so stale JSON is fully replaced.
+    "../../.vscode/tasks.json",
 ])
 
 # Fences whose body is refreshed each run from an upstream live feed

--- a/agentteams/frameworks/base.py
+++ b/agentteams/frameworks/base.py
@@ -81,6 +81,17 @@ class FrameworkAdapter(ABC):
         """
         return []
 
+    def vscode_tasks_rel_path(self) -> str | None:
+        """Return the path to .vscode/tasks.json relative to this framework's agents dir.
+
+        Default ``None`` disables tasks.json generation for this framework.
+        Override in adapters whose agents dir is exactly two levels deep from the
+        project root (e.g. ``.github/agents/``, ``.claude/agents/``, ``.goose/recipes/``).
+        AgentsMdAdapter must NOT override — its agents dir is one level deep and
+        ``../../`` would resolve above the project root.
+        """
+        return None
+
     @abstractmethod
     def get_file_extension(self, file_type: str) -> str:
         """Return the file extension for a given file type.

--- a/agentteams/frameworks/claude.py
+++ b/agentteams/frameworks/claude.py
@@ -94,6 +94,9 @@ class ClaudeAdapter(FrameworkAdapter):
     def get_agents_dir(self, project_path: Path) -> Path:
         return project_path / ".claude" / "agents"
 
+    def vscode_tasks_rel_path(self) -> str | None:
+        return "../../.vscode/tasks.json"
+
     def finalize_output_path(self, rel_path: str, file_type: str) -> str:
         """Map generic planned paths to Claude-native file names/locations."""
         if file_type == "instructions" and rel_path.endswith("copilot-instructions.md"):

--- a/agentteams/frameworks/copilot_vscode.py
+++ b/agentteams/frameworks/copilot_vscode.py
@@ -41,6 +41,9 @@ class CopilotVSCodeAdapter(FrameworkAdapter):
     def get_agents_dir(self, project_path: Path) -> Path:
         return project_path / ".github" / "agents"
 
+    def vscode_tasks_rel_path(self) -> str | None:
+        return "../../.vscode/tasks.json"
+
 
 # ---------------------------------------------------------------------------
 # YAML front matter helpers

--- a/agentteams/frameworks/goose.py
+++ b/agentteams/frameworks/goose.py
@@ -269,6 +269,9 @@ class GooseAdapter(FrameworkAdapter):
     def get_agents_dir(self, project_path: Path) -> Path:
         return project_path / ".goose" / "recipes"
 
+    def vscode_tasks_rel_path(self) -> str | None:
+        return "../../.vscode/tasks.json"
+
     def normalize_output_path(self, output: Path) -> Path:
         """Normalize a user-supplied --output path for the Goose framework.
 

--- a/agentteams/man.py
+++ b/agentteams/man.py
@@ -82,7 +82,17 @@ def generate_man_page(parser: argparse.ArgumentParser) -> str:
     lines.append(
         "Error: validation failure, file not found, "
         "drift detected (with \\fB--check\\fR), "
-        "or security issues (with \\fB--scan-security\\fR)."
+        "security issues (with \\fB--scan-security\\fR), "
+        "or a Tier-1 (blocking) finding (with \\fB--stale-check\\fR)."
+    )
+    lines.append(".TP")
+    lines.append(".B 2")
+    lines.append("Baseline drift detected (with \\fB--check-baseline\\fR).")
+    lines.append(".TP")
+    lines.append(".B 3")
+    lines.append(
+        "Reserved: remediation attempted but unresolved "
+        "(with \\fB--stale-check --stale-remediate\\fR)."
     )
 
     # EXAMPLES

--- a/agentteams/stale_detector.py
+++ b/agentteams/stale_detector.py
@@ -1,0 +1,739 @@
+"""
+stale_detector.py — read-only detection of stale agent docs and code/scripts.
+
+Scans a target repository and reports staleness across reliability-tiered signals
+(see references/plans/stale-detector-methods.report.md):
+
+- Tier 1 (deterministic, blocking): ``VCS_CONFLICT_MARKER`` (a full ordered git
+  merge-conflict triad), ``BROKEN_REF`` (a markdown-link target absent on disk),
+  and provenance-gated ``INTEGRITY`` / ``SOURCE_DRIFT``.
+- Tier 2 (heuristic, advisory): ``STALE_VS_CODE`` (referenced code committed after
+  the doc's last commit), plus inline/anchored broken references.
+- Tier 0 (INFO): ``PROVENANCE_ABSENT`` / ``BRIDGE_SOURCE_UNAVAILABLE``.
+
+This module is strictly read-only detection + the preview ``build_remediation_plan``.
+``.agentteams-stale-ignore`` (a gitignore-style file at the scan root) suppresses
+matching findings — never ``VCS_CONFLICT_MARKER``. The opt-in, ``--yes``-gated revision
+phase that actually writes (snapshot/restore, reference repair, bridge re-merge) lives in
+the sibling module ``agentteams/stale_remediate.py``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from agentteams import fleet
+
+# ---------------------------------------------------------------------------
+# Scan-set configuration
+# ---------------------------------------------------------------------------
+
+# Directories pruned during a non-git walk (a git work-tree uses ``git ls-files``,
+# which already excludes gitignored trees such as ``tmp/`` and backups).
+_PRUNE_DIRS = {
+    ".git", "__pycache__", "node_modules", ".agentteams-backups",
+    ".agentteams-fleet", "_site", "dist", ".pytest_cache", ".mypy_cache",
+}
+
+# Always skipped, even when tracked: these trees are fixtures or archival/ephemeral
+# records whose references to past state are expected to "age" and are not actionable
+# staleness. ``tmp/`` is the conventional scratch dir (gitignored in some repos, tracked
+# in others — skip it either way); ``examples/`` holds fixture trees (``expected/``);
+# ``workSummaries/`` are dated point-in-time logs.
+_SKIP_PREFIXES = ("examples/", "workSummaries/", "tmp/")
+
+# Generated/live-data paths whose churn is expected; suppressed from all but Tier-1
+# conflict-marker findings. Seeded from fleet's churn-suppression denylist.
+_VOLATILE_SUFFIXES = tuple(fleet._VOLATILE_SUFFIXES)
+
+_DOC_SUFFIXES = (".md",)
+_SCRIPT_SUFFIXES = (".py", ".sh")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Narrow, non-swallowing I/O helpers (CH-24: no broad catches, no pass/continue
+# bodies — each returns a sentinel so the caller decides what to skip).
+# ---------------------------------------------------------------------------
+
+def _safe_exists(p: Path) -> bool:
+    try:
+        return p.exists()
+    except OSError:
+        return False
+
+
+def _safe_read_text(p: Path) -> str | None:
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _safe_json(p: Path) -> dict | None:
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+@dataclass
+class StalenessFinding:
+    """One staleness signal at a location, with a confidence tier and action."""
+
+    tier: int  # 1 | 2 | 3 ; 0 == INFO (cannot-verify)
+    code: str
+    file: str  # repo-relative
+    line: int  # 1-based; 0 when not line-anchored
+    signal: str
+    detail: str
+    suggested_action: str
+    auto_remediable: bool = False
+    # For BROKEN_REF: the anchor-split bare reference path (used by ignore-matching and
+    # repair). Structured so callers never re-parse the human-readable ``detail`` string.
+    ref_target: str = ""
+
+
+@dataclass
+class StalenessReport:
+    root: str
+    scanned_files: int = 0
+    findings: list[StalenessFinding] = field(default_factory=list)
+    git_available: bool = False
+    recency_status: str = "ok"  # ok | unavailable:non-git | unavailable:shallow | disabled
+    provenance_sources: int = 0
+    suppressed_count: int = 0  # findings dropped by .agentteams-stale-ignore
+
+    @property
+    def tier1(self) -> list[StalenessFinding]:
+        return [f for f in self.findings if f.tier == 1]
+
+    @property
+    def tier2(self) -> list[StalenessFinding]:
+        return [f for f in self.findings if f.tier == 2]
+
+    @property
+    def tier3(self) -> list[StalenessFinding]:
+        return [f for f in self.findings if f.tier == 3]
+
+    @property
+    def info(self) -> list[StalenessFinding]:
+        return [f for f in self.findings if f.tier == 0]
+
+    @property
+    def has_blocking(self) -> bool:
+        return any(f.tier == 1 for f in self.findings)
+
+
+# ---------------------------------------------------------------------------
+# Fenced-code stripping (preserves 1-based line numbers)
+# ---------------------------------------------------------------------------
+
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def _strip_fenced_code(text: str) -> str:
+    """Blank the body and delimiters of fenced code blocks, preserving line count.
+
+    Each stripped line becomes empty so downstream detectors keep correct 1-based
+    line numbers. An unterminated fence blanks to end-of-file.
+    """
+    out: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        out.append("" if in_fence else line)
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# T1a — VCS conflict markers
+# ---------------------------------------------------------------------------
+
+_CONFLICT_OPEN = re.compile(r"^<<<<<<<(\s|$)")
+_CONFLICT_MID = re.compile(r"^=======\s*$")
+_CONFLICT_CLOSE = re.compile(r"^>>>>>>>(\s|$)")
+
+
+def detect_conflict_markers(text: str, rel_path: str) -> list[StalenessFinding]:
+    """Find complete, ordered git merge-conflict triads (Tier-1).
+
+    Requires ``<<<<<<<`` then ``=======`` then ``>>>>>>>`` in order with no second
+    ``<<<<<<<`` opening in between. A standalone ``=======`` (a Markdown setext
+    underline) is ignored. diff3 ``|||||||`` lines between open and mid are harmless.
+    Example blocks are excluded by stripping fenced code first.
+    """
+    findings: list[StalenessFinding] = []
+    lines = _strip_fenced_code(text).splitlines()
+    state = "OPEN"  # OPEN -> MID -> CLOSE
+    open_line = 0
+    for i, line in enumerate(lines, start=1):
+        if _CONFLICT_OPEN.match(line):
+            state, open_line = "MID", i
+            continue
+        if state == "MID" and _CONFLICT_MID.match(line):
+            state = "CLOSE"
+            continue
+        if state == "CLOSE" and _CONFLICT_CLOSE.match(line):
+            findings.append(StalenessFinding(
+                tier=1, code="VCS_CONFLICT_MARKER", file=rel_path, line=open_line,
+                signal="merge-conflict markers",
+                detail="unresolved git conflict triad (<<<<<<< ======= >>>>>>>)",
+                suggested_action="resolve the conflict by hand at this location; never auto-resolved",
+                auto_remediable=False,
+            ))
+            state, open_line = "OPEN", 0
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# References & broken-reference detection
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Reference:
+    raw: str
+    path: str
+    anchor: str  # "" when none
+    line: int
+    kind: str  # "md_link"
+
+
+_MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+_GLOB_VAR_CHARS = set("*?{}$~<>")
+
+
+def _suppress_ref(token: str) -> bool:
+    """True when a reference token is not a verifiable repo-relative path."""
+    if not token:
+        return True
+    low = token.lower()
+    if low.startswith(("http://", "https://", "mailto:", "//")):
+        return True
+    if token.startswith("#"):
+        return True
+    if token.startswith("/"):  # absolute machine path — illustrative, not verifiable
+        return True
+    if token.endswith("/"):  # directory-only reference
+        return True
+    if any(c in _GLOB_VAR_CHARS for c in token):
+        return True
+    return False
+
+
+def _split_anchor(token: str) -> tuple[str, str]:
+    """Split a trailing ``#anchor`` or ``:line`` off a path token."""
+    anchor = ""
+    if "#" in token:
+        token, anchor = token.split("#", 1)
+    # Strip a trailing ``:line`` or ``:symbol`` reference (e.g. ``file.py:42`` or
+    # ``module.py:func_name``) so the path itself can be resolved; the suffix marks
+    # the reference as anchored (Tier-2).
+    m = re.search(r":([\w.\-]+)$", token)
+    if m:
+        anchor = anchor or m.group(1)
+        token = token[: m.start()]
+    return token, anchor
+
+
+def extract_references(text: str) -> list[Reference]:
+    """Extract verifiable markdown-link references.
+
+    Only markdown links ``[text](path)`` are treated as references — they are
+    *intentional navigation*, so a broken one is a real problem. Inline-code path
+    mentions are deliberately NOT scanned: in living docs they routinely name
+    generated-output paths, illustrative examples, and historical locations that do
+    not exist in the source tree, producing false positives that erode trust.
+    """
+    refs: list[Reference] = []
+    for i, line in enumerate(_strip_fenced_code(text).splitlines(), start=1):
+        for m in _MD_LINK_RE.finditer(line):
+            tok = m.group(1).strip()
+            if _suppress_ref(tok):
+                continue
+            path, anchor = _split_anchor(tok)
+            if not path or _suppress_ref(path):
+                continue
+            refs.append(Reference(raw=tok, path=path, anchor=anchor, line=i, kind="md_link"))
+    return refs
+
+
+def _resolve_ref(ref: Reference, doc_path: Path, root: Path) -> Path | None:
+    """Return the resolved path for a reference, or None if it resolves nowhere."""
+    candidates = [doc_path.parent / ref.path, root / ref.path]
+    for cand in candidates:
+        if _safe_exists(cand):
+            return cand.resolve()
+    return None
+
+
+def detect_broken_refs(text: str, doc_path: Path, root: Path) -> list[StalenessFinding]:
+    """Flag references whose target is absent on disk (Tier-1 md-links / Tier-2 rest)."""
+    findings: list[StalenessFinding] = []
+    rel = _relpath(doc_path, root)
+    for ref in extract_references(text):
+        if _resolve_ref(ref, doc_path, root) is not None:
+            continue  # resolves; anchors are not validated in v1
+        tier1 = ref.kind == "md_link" and not ref.anchor
+        findings.append(StalenessFinding(
+            tier=1 if tier1 else 2,
+            code="BROKEN_REF", file=rel, line=ref.line,
+            signal="broken reference",
+            detail=f"reference {ref.raw!r} resolves to no file on disk",
+            suggested_action="update or remove the reference; if the file moved, point it at the new path",
+            auto_remediable=False,
+            ref_target=ref.path,
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# T2a — git-recency divergence
+# ---------------------------------------------------------------------------
+
+GitRunner = Callable[..., object]
+
+
+def _git_out(git: GitRunner, root: Path, *args: str) -> str | None:
+    """Run git and return stripped stdout, or None on non-zero exit."""
+    proc = git(root, *args)
+    if getattr(proc, "returncode", 1) != 0:
+        return None
+    return (getattr(proc, "stdout", "") or "").strip()
+
+
+def _is_shallow(git: GitRunner, root: Path) -> bool:
+    return _git_out(git, root, "rev-parse", "--is-shallow-repository") == "true"
+
+
+def detect_git_recency(
+    root: Path,
+    doc_to_refs: dict[str, set[str]],
+    *,
+    git: GitRunner = fleet._git,
+) -> tuple[list[StalenessFinding], str]:
+    """Flag docs whose referenced code changed in a commit after the doc's last commit.
+
+    Returns ``(findings, recency_status)``. Self-disables on non-git / shallow repos.
+    A finding requires both a commit strictly after the doc's last commit touching the
+    code AND a substantive (whitespace-filtered) diff — neutralizing reverts/cherry-picks.
+    """
+    if not fleet._is_git_repo(root):
+        return [], "unavailable:non-git"
+    if _is_shallow(git, root):
+        return [], "unavailable:shallow"
+
+    findings: list[StalenessFinding] = []
+    for doc_rel, code_rels in sorted(doc_to_refs.items()):
+        # Skip docs with uncommitted changes (an uncommitted fix would false-positive).
+        if _git_out(git, root, "status", "--porcelain", "--", doc_rel):
+            continue
+        doc_commit = _git_out(git, root, "rev-list", "-1", "HEAD", "--", doc_rel)
+        if not doc_commit:
+            continue  # untracked / no history
+        for code_rel in sorted(code_rels):
+            if _git_out(git, root, "status", "--porcelain", "--", code_rel):
+                continue
+            after = _git_out(git, root, "rev-list", f"{doc_commit}..HEAD", "--", code_rel)
+            if not after:
+                continue  # code unchanged since the doc's last commit
+            diff = _git_out(git, root, "diff", "-w", doc_commit, "HEAD", "--", code_rel)
+            if not diff:
+                continue  # whitespace-only / reverted to identical content
+            findings.append(StalenessFinding(
+                tier=2, code="STALE_VS_CODE", file=doc_rel, line=0,
+                signal="doc older than referenced code",
+                detail=(
+                    f"{code_rel} changed after {doc_rel}'s last commit "
+                    f"({doc_commit[:8]}); the doc may describe outdated behavior "
+                    "(whitespace filtered; comment/format-only changes not excluded)"
+                ),
+                suggested_action=f"review {doc_rel} against current {code_rel} and update if stale",
+                auto_remediable=False,
+            ))
+    return findings, "ok"
+
+
+# ---------------------------------------------------------------------------
+# Provenance-gated detectors (T1c integrity / T1d bridge drift)
+# ---------------------------------------------------------------------------
+
+def _provenance_paths(root: Path, pattern: str, allowed_rel: set[str] | None) -> list[Path]:
+    """Discovered provenance files, restricted to the scan-set when one is given.
+
+    ``allowed_rel`` is the relative-path set the aggregator already filtered through
+    ``git ls-files`` / prune / ``examples`` skip — applying it here keeps gitignored
+    sandboxes (``tmp/``) and fixture trees from flooding provenance findings.
+    """
+    out: list[Path] = []
+    for p in sorted(root.rglob(pattern)):
+        if allowed_rel is not None and _relpath(p, root) not in allowed_rel:
+            continue
+        out.append(p)
+    return out
+
+
+def detect_integrity(root: Path, allowed_rel: set[str] | None = None) -> list[StalenessFinding]:
+    """Reuse drift.verify_output_integrity for every discovered build-log."""
+    from agentteams import drift
+
+    findings: list[StalenessFinding] = []
+    for build_log in _provenance_paths(root, "references/build-log.json", allowed_rel):
+        agents_dir = build_log.parent.parent
+        try:
+            results = drift.verify_output_integrity(agents_dir)
+        except (OSError, ValueError):
+            results = []  # unreadable/corrupt build-log — skip this source, don't crash
+        for entry in results:
+            status = entry.get("status")
+            rel = _relpath(Path(entry.get("path", "")), root) if entry.get("path") else entry.get("rel_path", "")
+            if status in ("FENCE-BROKEN", "TRUNCATED", "MISSING"):
+                findings.append(StalenessFinding(
+                    tier=1, code="INTEGRITY", file=rel, line=0,
+                    signal=f"generated file {status}",
+                    detail=entry.get("note", ""),
+                    suggested_action=f"re-run `agentteams --update --merge --output {agents_dir}`",
+                    auto_remediable=True,
+                ))
+            elif status == "MODIFIED":
+                findings.append(StalenessFinding(
+                    tier=2, code="INTEGRITY", file=rel, line=0,
+                    signal="generated file MODIFIED",
+                    detail=entry.get("note", ""),
+                    suggested_action="review (legitimate USER-EDITABLE edit or drift)",
+                    auto_remediable=False,
+                ))
+    return findings
+
+
+def detect_bridge_drift(root: Path, allowed_rel: set[str] | None = None) -> list[StalenessFinding]:
+    """Check each bridge manifest's source freshness, gated on source presence."""
+    from agentteams import bridge
+
+    findings: list[StalenessFinding] = []
+    for manifest_path in _provenance_paths(
+        root, "references/bridges/*/bridge-manifest.json", allowed_rel
+    ):
+        manifest = _safe_json(manifest_path)
+        if manifest is None:
+            continue  # unreadable/corrupt manifest — outside any try block
+        source_dir = Path(manifest.get("source_dir", ""))
+        rel_manifest = _relpath(manifest_path, root)
+        try:
+            files = bridge._collect_source_files(source_dir) if source_dir.is_dir() else []
+        except OSError:
+            files = []  # source unreadable — treat as unavailable below
+        if not files:
+            findings.append(StalenessFinding(
+                tier=0, code="BRIDGE_SOURCE_UNAVAILABLE", file=rel_manifest, line=0,
+                signal="bridge source not present",
+                detail=f"source_dir {source_dir} is not available on this machine",
+                suggested_action=(
+                    f"run `agentteams --bridge-from {source_dir} --bridge-check` "
+                    "where the source is present to verify bridge freshness"
+                ),
+                auto_remediable=False,
+            ))
+            continue
+        try:
+            rows = bridge._compute_hash_rows(files, source_dir)
+            ok, _report = bridge._run_bridge_check(manifest_path=manifest_path, source_hash_rows=rows)
+        except (OSError, ValueError, KeyError, TypeError):
+            ok = None  # bridge check failed to run — skip (assignment body, not a swallow)
+        if ok is None:
+            continue
+        if not ok:
+            findings.append(StalenessFinding(
+                tier=1, code="SOURCE_DRIFT", file=rel_manifest, line=0,
+                signal="bridge source diverged",
+                detail="source agent files differ from the bridge-manifest snapshot",
+                suggested_action=f"re-run `agentteams --bridge-from {source_dir} --bridge-merge`",
+                auto_remediable=True,
+            ))
+    return findings
+
+
+def detect_provenance(root: Path, allowed_rel: set[str] | None = None) -> list[StalenessFinding]:
+    """Integrity ∪ bridge drift; a single INFO when no provenance exists anywhere."""
+    integrity = detect_integrity(root, allowed_rel)
+    bridge_findings = detect_bridge_drift(root, allowed_rel)
+    have_build_log = bool(_provenance_paths(root, "references/build-log.json", allowed_rel))
+    have_bridge = bool(
+        _provenance_paths(root, "references/bridges/*/bridge-manifest.json", allowed_rel)
+    )
+    if not have_build_log and not have_bridge:
+        return [StalenessFinding(
+            tier=0, code="PROVENANCE_ABSENT", file=".", line=0,
+            signal="no generation provenance",
+            detail="no references/build-log.json or bridge-manifest.json found under the scan root",
+            suggested_action="generated-artifact integrity cannot be verified on this target",
+            auto_remediable=False,
+        )]
+    return integrity + bridge_findings
+
+
+# ---------------------------------------------------------------------------
+# File-set & aggregator
+# ---------------------------------------------------------------------------
+
+def _relpath(path: Path, root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except (ValueError, OSError):
+        return str(path)
+
+
+def _skip_rel(rel: str) -> bool:
+    if any(rel == s or rel.startswith(s) for s in _SKIP_PREFIXES):
+        return True
+    parts = set(Path(rel).parts)
+    return bool(parts & _PRUNE_DIRS)
+
+
+def _iter_scan_files(root: Path, git: GitRunner = fleet._git) -> list[Path]:
+    """Tracked files via ``git ls-files`` in a work-tree; else a pruned walk."""
+    files: list[Path] = []
+    if fleet._is_git_repo(root):
+        out = _git_out(git, root, "ls-files")
+        for rel in (out or "").splitlines():
+            rel = rel.strip()
+            if not rel or _skip_rel(rel):
+                continue
+            p = root / rel
+            if p.is_file():
+                files.append(p)
+        return files
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        rel = _relpath(p, root)
+        if _skip_rel(rel):
+            continue
+        files.append(p)
+    return files
+
+
+def _is_volatile(rel: str) -> bool:
+    return any(rel.endswith(s) or rel == s for s in _VOLATILE_SUFFIXES)
+
+
+# ---------------------------------------------------------------------------
+# .agentteams-stale-ignore — maintainer-controlled finding suppression
+# ---------------------------------------------------------------------------
+
+_STALE_IGNORE_FILE = ".agentteams-stale-ignore"
+
+
+def _load_stale_ignore(root: Path) -> list[str]:
+    """Read ``<root>/.agentteams-stale-ignore`` (gitignore-style); missing → []."""
+    text = _safe_read_text(root / _STALE_IGNORE_FILE)
+    if text is None:
+        return []
+    out: list[str] = []
+    for line in text.splitlines():
+        s = line.strip()
+        if s and not s.startswith("#"):
+            out.append(s)
+    return out
+
+
+def _match_ignore(rel_path: str, pattern: str) -> bool:
+    """Match a POSIX relative path against one ignore pattern.
+
+    Not bare fnmatch (fnmatch != gitignore). Supports: exact path; **dir-prefix**
+    (``dir`` or ``dir/`` matches the directory and everything under it); and ``*`` globs.
+    """
+    pat = pattern.rstrip("/")
+    if not pat:
+        return False
+    if rel_path == pat or rel_path.startswith(pat + "/"):
+        return True
+    return fnmatch.fnmatch(rel_path, pat)
+
+
+def _is_ignored(finding: StalenessFinding, patterns: list[str]) -> bool:
+    """True when a finding should be suppressed. VCS_CONFLICT_MARKER is NEVER
+    suppressible — a complete conflict triad is always broken."""
+    if finding.code == "VCS_CONFLICT_MARKER":
+        return False
+    targets = [finding.file]
+    if finding.code == "BROKEN_REF" and finding.ref_target:
+        targets.append(finding.ref_target)
+    return any(_match_ignore(t, p) for t in targets for p in patterns)
+
+
+def scan_staleness(
+    root: Path,
+    *,
+    include_git: bool = True,
+    git: GitRunner = fleet._git,
+) -> StalenessReport:
+    """Run all detectors over ``root`` and return an aggregated read-only report."""
+    root = Path(root)
+    report = StalenessReport(root=str(root), git_available=fleet._is_git_repo(root))
+
+    files = _iter_scan_files(root, git)
+    report.scanned_files = len(files)
+    allowed_rel = {_relpath(p, root) for p in files}
+
+    doc_to_refs: dict[str, set[str]] = {}
+    for path in files:
+        rel = _relpath(path, root)
+        suffix = path.suffix.lower()
+        is_doc = suffix in _DOC_SUFFIXES
+        is_script = suffix in _SCRIPT_SUFFIXES
+        if not (is_doc or is_script):
+            continue
+        text = _safe_read_text(path)
+        if text is None:
+            continue
+
+        # Tier-1 conflict markers on docs AND scripts (not volatile-suppressed).
+        report.findings.extend(detect_conflict_markers(text, rel))
+
+        if is_doc and not _is_volatile(rel):
+            report.findings.extend(detect_broken_refs(text, path, root))
+            # Build doc->code map for recency (only existing code targets).
+            code_targets: set[str] = set()
+            for ref in extract_references(text):
+                resolved = _resolve_ref(ref, path, root)
+                if resolved is None:
+                    continue
+                if resolved.suffix.lower() in (_SCRIPT_SUFFIXES + _DOC_SUFFIXES):
+                    code_targets.add(_relpath(resolved, root))
+            code_targets.discard(rel)
+            if code_targets:
+                doc_to_refs[rel] = code_targets
+
+    if include_git:
+        recency, status = detect_git_recency(root, doc_to_refs, git=git)
+        report.findings.extend(recency)
+        report.recency_status = status
+    else:
+        report.recency_status = "disabled"
+
+    provenance = detect_provenance(root, allowed_rel)
+    report.findings.extend(provenance)
+    report.provenance_sources = (
+        len(_provenance_paths(root, "references/build-log.json", allowed_rel))
+        + len(_provenance_paths(root, "references/bridges/*/bridge-manifest.json", allowed_rel))
+    )
+
+    # Suppress findings matched by .agentteams-stale-ignore (maintainer intent) BEFORE
+    # dedupe/exit-code/remediation so they drop out of every downstream consumer. A
+    # conflict triad is never suppressible (see _is_ignored).
+    ignore_patterns = _load_stale_ignore(root)
+    if ignore_patterns:
+        kept = [f for f in report.findings if not _is_ignored(f, ignore_patterns)]
+        report.suppressed_count = len(report.findings) - len(kept)
+        report.findings = kept
+
+    # Dedupe: the same physical file can be recorded in more than one build-log
+    # (e.g. .vscode/tasks.json emitted by both the github and goose agents dirs),
+    # which would otherwise report one finding per provenance source.
+    seen: set[tuple] = set()
+    deduped: list[StalenessFinding] = []
+    for f in report.findings:
+        key = (f.tier, f.code, f.file, f.line, f.detail)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(f)
+    deduped.sort(key=lambda f: (f.tier if f.tier else 99, f.file, f.line))
+    report.findings = deduped
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Reporting, exit code, remediation
+# ---------------------------------------------------------------------------
+
+def exit_code(report: StalenessReport) -> int:
+    """0 clean; 1 any Tier-1 (blocking). (3 reserved for unresolved remediation.)"""
+    return 1 if report.has_blocking else 0
+
+
+def print_staleness_report(report: StalenessReport) -> None:
+    import sys
+
+    print(f"Stale-check: scanned {report.scanned_files} file(s) under {report.root}")
+    suppressed = f" | suppressed: {report.suppressed_count}" if report.suppressed_count else ""
+    print(
+        f"  git: {'yes' if report.git_available else 'no'} | "
+        f"recency: {report.recency_status} | "
+        f"provenance sources: {report.provenance_sources}{suppressed}"
+    )
+    if not report.findings:
+        print("  ✓  No staleness detected.")
+        return
+
+    for f in report.tier1:
+        loc = f"{f.file}:{f.line}" if f.line else f.file
+        print(f"  [TIER-1 {f.code}] {loc} — {f.detail}", file=sys.stderr)
+    for f in report.tier2:
+        loc = f"{f.file}:{f.line}" if f.line else f.file
+        print(f"  [tier-2 {f.code}] {loc} — {f.detail}")
+    for f in report.tier3:
+        loc = f"{f.file}:{f.line}" if f.line else f.file
+        print(f"  [tier-3 {f.code}] {loc} — {f.detail}")
+    for f in report.info:
+        print(f"  [info  {f.code}] {f.file} — {f.detail}")
+
+    n1, n2 = len(report.tier1), len(report.tier2)
+    print(
+        f"\n{n1} blocking (Tier-1), {n2} advisory (Tier-2), "
+        f"{len(report.tier3)} Tier-3, {len(report.info)} info."
+    )
+    if report.has_blocking:
+        print("Blocking staleness found — see Tier-1 findings above.", file=sys.stderr)
+
+
+def build_remediation_plan(report: StalenessReport) -> list[dict]:
+    """Per actionable finding, a suggested action (no file writes in v1)."""
+    plan: list[dict] = []
+    for f in report.findings:
+        if f.code == "VCS_CONFLICT_MARKER":
+            plan.append({
+                "code": f.code, "file": f.file,
+                "action": "manual", "command": None,
+                "manual_reason": "merge-conflict markers are never auto-resolved; resolve by hand",
+            })
+        elif f.code in ("INTEGRITY", "SOURCE_DRIFT") and f.auto_remediable:
+            plan.append({
+                "code": f.code, "file": f.file,
+                "action": "run-safe-writer", "command": f.suggested_action,
+                "manual_reason": None,
+            })
+        elif f.code == "BROKEN_REF":
+            plan.append({
+                "code": f.code, "file": f.file,
+                "action": "manual", "command": None,
+                "manual_reason": "update the reference; rename auto-fix is not applied in v1",
+            })
+    return plan
+
+
+def print_remediation_plan(plan: list[dict]) -> None:
+    if not plan:
+        print("\nRemediation: nothing actionable.")
+        return
+    print(f"\nRemediation plan ({len(plan)} item(s)) — suggested only, no files edited:")
+    for row in plan:
+        if row["action"] == "run-safe-writer":
+            print(f"  [{row['code']}] {row['file']}: {row['command']}")
+        else:
+            print(f"  [{row['code']}] {row['file']}: MANUAL — {row['manual_reason']}")
+    print("  (re-run with --stale-remediate --yes to apply the safe revisions)")
+

--- a/agentteams/stale_remediate.py
+++ b/agentteams/stale_remediate.py
@@ -1,0 +1,328 @@
+"""
+stale_remediate.py — the opt-in, ``--yes``-gated revision phase for stale findings.
+
+Split from ``stale_detector.py`` (CH-07: keep modules under the line ceiling; detection
+vs. write-phase are a clean seam). Takes a sha256-verified safety snapshot of every file
+it will touch into ``.agentteams-backups/stale-fix-<ts>/`` (recoverable via
+``restore_snapshot`` / ``--stale-restore``) BEFORE writing, then performs only safe,
+deterministic revisions — broken-reference relocation repair (never inside a fenced /
+USER-EDITABLE region) and bridge re-merge for ``SOURCE_DRIFT`` (the canonical fence-aware
+writer). ``INTEGRITY`` is routed (the ``--update --merge`` command is printed, not
+auto-run). Conflict markers are never auto-resolved.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agentteams import fleet
+from agentteams.stale_detector import (
+    GitRunner,
+    StalenessReport,
+    _iter_scan_files,
+    _relpath,
+    _safe_json,
+    _safe_read_text,
+)
+
+_SNAPSHOT_PREFIX = "stale-fix-"
+
+# A file carrying any managed/user-editable fence is never auto-edited by the
+# reference repairer (route to manual) — only the canonical writers touch fences.
+_FENCE_MARKER_RE = re.compile(r"AGENTTEAMS(-BRIDGE)?:(BEGIN|END)|USER[- ]?EDITABLE", re.I)
+
+
+@dataclass
+class FixAction:
+    code: str
+    file: str
+    action: str  # repaired-ref | bridge-merge | routed | manual | failed
+    applied: bool
+    detail: str
+
+
+@dataclass
+class FixResult:
+    snapshot_dir: str | None
+    actions: list[FixAction] = field(default_factory=list)
+    applied: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def n_applied(self) -> int:
+        return sum(1 for a in self.actions if a.applied)
+
+    @property
+    def n_unresolved(self) -> int:
+        # Blocking findings left for manual handling (the exit-3 condition).
+        return sum(1 for a in self.actions if a.action in ("manual", "failed", "routed"))
+
+
+# --- safety snapshot / restore --------------------------------------------
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def snapshot_files(root: Path, rel_paths: list[str], *, stamp: str | None = None) -> Path | None:
+    """Copy each existing file into ``.agentteams-backups/stale-fix-<ts>/files/<rel>``
+    with a sha256 manifest. Returns the snapshot dir, or None if nothing to snapshot."""
+    rels = sorted({r for r in rel_paths if (root / r).is_file()})
+    if not rels:
+        return None
+    snap = root / ".agentteams-backups" / f"{_SNAPSHOT_PREFIX}{stamp or _utc_stamp()}"
+    files_dir = snap / "files"
+    entries: list[dict[str, str]] = []
+    for rel in rels:
+        data = (root / rel).read_bytes()
+        dst = files_dir / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(data)
+        entries.append({"rel": rel, "sha256": hashlib.sha256(data).hexdigest()})
+    snap.mkdir(parents=True, exist_ok=True)
+    (snap / "manifest.json").write_text(
+        json.dumps({"created_utc": _utc_stamp(), "files": entries}, indent=2),
+        encoding="utf-8",
+    )
+    return snap
+
+
+def _backups_ignored(root: Path, git: GitRunner, sample_rel: str) -> bool:
+    """True when ``.agentteams-backups/`` is gitignored (or the repo is non-git, where the
+    warning is n/a). Checks an EXISTING path (the just-written snapshot), because a
+    trailing-slash gitignore pattern does not match a non-existent bare directory."""
+    if not fleet._is_git_repo(root):
+        return True  # n/a — no warning for non-git targets
+    return git(root, "check-ignore", "-q", sample_rel).returncode == 0
+
+
+def latest_snapshot(root: Path) -> Path | None:
+    base = root / ".agentteams-backups"
+    if not base.is_dir():
+        return None
+    snaps = sorted(p for p in base.glob(f"{_SNAPSHOT_PREFIX}*") if (p / "manifest.json").is_file())
+    return snaps[-1] if snaps else None
+
+
+def restore_snapshot(root: Path, snap_dir: Path) -> list[str]:
+    """Restore every file recorded in a snapshot back to ``root``, verifying the
+    backup's own sha256 first. Returns the restored relative paths. Raises ValueError
+    if the manifest is unreadable or a backup file is corrupt (fail-safe: write nothing)."""
+    manifest = _safe_json(snap_dir / "manifest.json")
+    if manifest is None:
+        raise ValueError(f"unreadable snapshot manifest: {snap_dir / 'manifest.json'}")
+    planned: list[tuple[str, bytes]] = []
+    for entry in manifest.get("files", []):
+        rel = entry["rel"]
+        backup_file = snap_dir / "files" / rel
+        if not backup_file.is_file():
+            raise ValueError(f"snapshot missing backup for {rel}")
+        data = backup_file.read_bytes()
+        if hashlib.sha256(data).hexdigest() != entry.get("sha256"):
+            raise ValueError(f"snapshot backup corrupt for {rel} (sha256 mismatch)")
+        planned.append((rel, data))
+    # All verified — now write (so a corrupt backup never leaves a half-restore).
+    restored: list[str] = []
+    for rel, data in planned:
+        dst = root / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(data)
+        restored.append(rel)
+    return restored
+
+
+# --- broken-reference repair ----------------------------------------------
+
+def _relocate_target(ref_path: str, tracked: list[str]) -> str | None:
+    """If the reference's basename matches exactly one tracked file, return that
+    relative path (a deterministic 'file moved' repair); else None."""
+    base = ref_path.rsplit("/", 1)[-1]
+    if not base or "." not in base:
+        return None
+    matches = [t for t in tracked if t == base or t.endswith("/" + base)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _plan_ref_repairs(report: StalenessReport, root: Path, tracked: list[str]) -> list[dict]:
+    """For each BROKEN_REF, compute a deterministic relocation rewrite if one exists
+    and the host file carries no fences. Returns plan rows (no writes)."""
+    plans: list[dict] = []
+    for f in report.findings:
+        if f.code != "BROKEN_REF" or not f.ref_target:
+            continue
+        ref_path = f.ref_target
+        target = _relocate_target(ref_path, tracked)
+        if target is None:
+            continue
+        doc = root / f.file
+        text = _safe_read_text(doc)
+        if text is None or _FENCE_MARKER_RE.search(text):
+            continue  # never auto-edit a fenced/managed file
+        # New href relative to the doc's directory.
+        new_href = _rel_href(f.file, target)
+        if new_href is None or new_href == ref_path:
+            continue
+        plans.append({"file": f.file, "old": ref_path, "ref_path": ref_path,
+                      "new_href": new_href, "line": f.line})
+    return plans
+
+
+def _rel_href(doc_rel: str, target_rel: str) -> str | None:
+    """Relative href from a doc to a target (both repo-relative POSIX), or None."""
+    try:
+        rel = os.path.relpath(Path(target_rel), Path(doc_rel).parent)
+    except ValueError:
+        return None  # e.g. cross-drive on Windows — not repairable
+    return Path(rel).as_posix()
+
+
+def _apply_ref_repair(root: Path, plan: dict) -> bool:
+    """Rewrite the broken link to the relocated target. Returns True on a real change."""
+    doc = root / plan["file"]
+    text = _safe_read_text(doc)
+    if text is None:
+        return False
+    # Replace the href inside the markdown link target only (…](old)).
+    needle = f"]({plan['old']})"
+    repl = f"]({plan['new_href']})"
+    if needle not in text:
+        return False
+    doc.write_text(text.replace(needle, repl), encoding="utf-8")
+    return True
+
+
+# --- orchestration ---------------------------------------------------------
+
+def _bridge_target_rels(root: Path) -> list[str]:
+    """The bounded set of files a --bridge-merge may touch, for snapshotting."""
+    rels: list[str] = []
+    for pattern in (".claude/**/*", "CLAUDE.md", "AGENTS.md", "references/bridges/**/*"):
+        for p in root.glob(pattern):
+            if p.is_file():
+                rels.append(_relpath(p, root))
+    return rels
+
+
+def _run_bridge_merge(root: Path, manifest_path: Path) -> bool:
+    """Invoke the canonical fence-aware --bridge-merge writer for one manifest.
+    Returns True on success (exit 0)."""
+    manifest = _safe_json(manifest_path)
+    if manifest is None:
+        return False
+    source_dir = Path(manifest.get("source_dir", ""))
+    if not source_dir.is_dir():
+        return False
+    from agentteams.cli.commands import _run_bridge
+    rc = _run_bridge(
+        source_dir=source_dir,
+        source_framework=manifest.get("source_framework"),
+        target_framework=manifest.get("target_framework", "claude"),
+        output=root,
+        dry_run=False,
+        overwrite=False,
+        check_only=False,
+        merge_only=True,
+    )
+    return rc == 0
+
+
+def apply_fixes(
+    report: StalenessReport,
+    root: Path,
+    *,
+    apply: bool,
+    git: GitRunner = fleet._git,
+) -> FixResult:
+    """Plan (and, when ``apply``, perform) safe revisions for the report's findings.
+
+    When ``apply`` is True a verified safety snapshot of every file to be touched is
+    written first, so any bad revision is recoverable via ``restore_snapshot``.
+    """
+    root = Path(root)
+    tracked = [_relpath(p, root) for p in _iter_scan_files(root, git)]
+    ref_plans = _plan_ref_repairs(report, root, tracked)
+    source_drift = [f for f in report.findings if f.code == "SOURCE_DRIFT"]
+
+    result = FixResult(snapshot_dir=None, applied=apply)
+
+    if apply:
+        touch = [p["file"] for p in ref_plans]
+        if source_drift:
+            touch += _bridge_target_rels(root)
+        snap = snapshot_files(root, touch)
+        result.snapshot_dir = str(snap) if snap else None
+        if snap is not None and not _backups_ignored(root, git, _relpath(snap, root)):
+            result.warnings.append(
+                ".agentteams-backups/ is not gitignored here — the safety snapshot will "
+                "show as untracked files. Add '.agentteams-backups/' to .gitignore."
+            )
+
+    # 1) Broken-reference repairs (deterministic relocation).
+    for plan in ref_plans:
+        if apply:
+            ok = _apply_ref_repair(root, plan)
+            result.actions.append(FixAction(
+                "BROKEN_REF", plan["file"], "repaired-ref" if ok else "failed", ok,
+                f"{plan['ref_path']} -> {plan['new_href']}",
+            ))
+        else:
+            result.actions.append(FixAction(
+                "BROKEN_REF", plan["file"], "repaired-ref", False,
+                f"would relocate {plan['ref_path']} -> {plan['new_href']}",
+            ))
+
+    # 2) SOURCE_DRIFT -> canonical --bridge-merge writer.
+    for f in source_drift:
+        manifest_path = root / f.file
+        if apply:
+            ok = _run_bridge_merge(root, manifest_path)
+            result.actions.append(FixAction(
+                "SOURCE_DRIFT", f.file, "bridge-merge" if ok else "failed", ok,
+                "re-merged bridge" if ok else "bridge-merge failed (snapshot preserved)",
+            ))
+        else:
+            result.actions.append(FixAction(
+                "SOURCE_DRIFT", f.file, "bridge-merge", False, "would run --bridge-merge",
+            ))
+
+    # 3) INTEGRITY -> routed (printed command, not auto-run). 4) others -> manual.
+    for f in report.findings:
+        if f.code == "INTEGRITY" and f.tier == 1:
+            result.actions.append(FixAction(
+                "INTEGRITY", f.file, "routed", False, f.suggested_action,
+            ))
+        elif f.code == "VCS_CONFLICT_MARKER":
+            result.actions.append(FixAction(
+                "VCS_CONFLICT_MARKER", f.file, "manual", False,
+                "never auto-resolved; fix by hand",
+            ))
+        elif f.code == "BROKEN_REF" and not any(p["file"] == f.file and p["line"] == f.line for p in ref_plans):
+            result.actions.append(FixAction(
+                "BROKEN_REF", f.file, "manual", False,
+                "no unambiguous relocated target; update by hand",
+            ))
+    return result
+
+
+def print_fix_result(result: FixResult) -> None:
+    import sys
+
+    verb = "Applied" if result.applied else "Would apply"
+    for w in result.warnings:
+        print(f"  ⚠  {w}", file=sys.stderr)
+    if result.snapshot_dir:
+        print(f"\nSafety snapshot: {result.snapshot_dir}")
+        print("  (recover with: agentteams --stale-restore  — restores the latest snapshot)")
+    print(f"\nRevision plan ({len(result.actions)} item(s)) — {verb.lower()}:")
+    for a in result.actions:
+        mark = "✓" if a.applied else ("→" if a.action in ("routed", "manual", "bridge-merge", "repaired-ref") else "✗")
+        stream = sys.stderr if a.action == "failed" else sys.stdout
+        print(f"  {mark} [{a.code}] {a.file}: {a.action} — {a.detail}", file=stream)
+    if result.applied:
+        print(f"\n{result.n_applied} revision(s) applied; {result.n_unresolved} need manual/routed handling.")

--- a/agentteams/vscode_tasks.py
+++ b/agentteams/vscode_tasks.py
@@ -1,0 +1,529 @@
+"""
+vscode_tasks.py — Discovery, rendering, and sentinel-merge for .vscode/tasks.json.
+
+Discovers runnable commands from project tooling files (package.json, Makefile,
+pyproject.toml, tox.ini, Taskfile.yml, scripts/*.sh) and emits a tasks.json
+file tagged with "detail": "AGENTTEAMS" so it can be safely merged on re-runs
+while preserving user-authored tasks.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Safety allowlist for task names
+# ---------------------------------------------------------------------------
+
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_.:\- ]+$")
+
+
+def _safe_name(name: str) -> bool:
+    """Return True when a task name is safe to include in JSON output.
+
+    Rejects names with shell-expansion characters, path separators, or other
+    metacharacters that could produce harmful or malformed task entries.
+    """
+    return bool(name and _SAFE_NAME_RE.fullmatch(name))
+
+
+# ---------------------------------------------------------------------------
+# ProjectCommand dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProjectCommand:
+    label: str
+    command: str
+    group: str = "none"      # "test" | "build" | "none"
+    is_default: bool = False
+    presentation: "dict[str, Any] | None" = None  # None → default (panel: shared)
+
+
+# ---------------------------------------------------------------------------
+# Group classifier
+# ---------------------------------------------------------------------------
+
+_TEST_KEYWORDS = ("test", "spec", "check", "lint", "verify", "qa")
+_BUILD_KEYWORDS = ("build", "compile", "bundle", "dist", "package", "install")
+
+
+def _classify_group(name: str) -> str:
+    n = name.lower()
+    if any(k in n for k in _TEST_KEYWORDS):
+        return "test"
+    if any(k in n for k in _BUILD_KEYWORDS):
+        return "build"
+    return "none"
+
+
+def _assign_group_defaults(commands: list[ProjectCommand]) -> None:
+    """Mark the first test-group and first build-group command as group defaults."""
+    saw_test = False
+    saw_build = False
+    for cmd in commands:
+        if cmd.group == "test" and not saw_test:
+            cmd.is_default = True
+            saw_test = True
+        elif cmd.group == "build" and not saw_build:
+            cmd.is_default = True
+            saw_build = True
+
+
+# ---------------------------------------------------------------------------
+# Per-source discoverers
+# ---------------------------------------------------------------------------
+
+def _from_package_json(project_path: Path) -> list[ProjectCommand]:
+    p = project_path / "package.json"
+    if not p.is_file():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return []
+    commands: list[ProjectCommand] = []
+    for name in (data.get("scripts") or {}):
+        if not isinstance(name, str) or not _safe_name(name):
+            continue
+        commands.append(ProjectCommand(
+            label=f"npm: {name}",
+            command=f"npm run {name}",
+            group=_classify_group(name),
+        ))
+    return commands
+
+
+_PHONY_RE = re.compile(r"^\.PHONY\s*:\s*(.+)$", re.MULTILINE)
+
+
+def _from_makefile(project_path: Path) -> list[ProjectCommand]:
+    p = project_path / "Makefile"
+    if not p.is_file():
+        return []
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    commands: list[ProjectCommand] = []
+    for m in _PHONY_RE.finditer(text):
+        for name in m.group(1).split():
+            name = name.strip()
+            if not name or not _safe_name(name):
+                continue
+            commands.append(ProjectCommand(
+                label=f"make: {name}",
+                command=f"make {name}",
+                group=_classify_group(name),
+            ))
+    return commands
+
+
+_TASK_SECTION_RE = re.compile(
+    r"^\[tool\.(?:taskipy|poethepoet|poe)\.tasks\]", re.MULTILINE
+)
+_NEXT_SECTION_RE = re.compile(r"^\[", re.MULTILINE)
+
+
+def _from_pyproject_toml(project_path: Path) -> list[ProjectCommand]:
+    p = project_path / "pyproject.toml"
+    if not p.is_file():
+        return []
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    commands: list[ProjectCommand] = []
+    for m in _TASK_SECTION_RE.finditer(text):
+        section_start = m.end()
+        next_section = _NEXT_SECTION_RE.search(text, section_start)
+        block = text[section_start: next_section.start() if next_section else None]
+        for line in block.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            name = line.split("=", 1)[0].strip()
+            if not name or not _safe_name(name):
+                continue
+            commands.append(ProjectCommand(
+                label=f"task: {name}",
+                command=f"task {name}",
+                group=_classify_group(name),
+            ))
+    return commands
+
+
+_TESTENV_RE = re.compile(r"^\[testenv:([^\]]+)\]", re.MULTILINE)
+
+
+def _from_tox_ini(project_path: Path) -> list[ProjectCommand]:
+    p = project_path / "tox.ini"
+    if not p.is_file():
+        return []
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    return [
+        ProjectCommand(
+            label=f"tox: {m.group(1)}",
+            command=f"tox -e {m.group(1)}",
+            group="test",
+        )
+        for m in _TESTENV_RE.finditer(text)
+        if _safe_name(m.group(1))
+    ]
+
+
+_TASKFILE_TASKS_RE = re.compile(r"^tasks:\s*$", re.MULTILINE)
+_TASKFILE_RESERVED = frozenset({
+    "tasks", "vars", "env", "includes", "version",
+    "silent", "run", "output", "method", "cmds",
+    "deps", "desc", "dir", "ignore_error", "internal",
+    "label", "preconditions", "prompt", "requires",
+    "sources", "generates", "status", "set", "shopt",
+})
+
+
+def _from_taskfile(project_path: Path) -> list[ProjectCommand]:
+    for name in ("Taskfile.yml", "Taskfile.yaml"):
+        p = project_path / name
+        if p.is_file():
+            break
+    else:
+        return []
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    tasks_match = _TASKFILE_TASKS_RE.search(text)
+    if not tasks_match:
+        return []
+
+    after_tasks = text[tasks_match.end():]
+    # Detect indent level from first indented line under `tasks:`.
+    first_indent = re.search(r"^( +)\w", after_tasks, re.MULTILINE)
+    if not first_indent:
+        return []
+    indent = first_indent.group(1)
+    # Collect only lines at exactly the task-key indent level.
+    end_block = re.search(r"^\S", after_tasks, re.MULTILINE)
+    block = after_tasks[:end_block.start()] if end_block else after_tasks
+    key_re = re.compile(rf"^{re.escape(indent)}(\w[\w\-]+):\s*$", re.MULTILINE)
+
+    return [
+        ProjectCommand(
+            label=f"task: {m.group(1)}",
+            command=f"task {m.group(1)}",
+            group=_classify_group(m.group(1)),
+        )
+        for m in key_re.finditer(block)
+        if m.group(1) not in _TASKFILE_RESERVED and _safe_name(m.group(1))
+    ]
+
+
+def _from_scripts_dir(project_path: Path) -> list[ProjectCommand]:
+    scripts_dir = project_path / "scripts"
+    if not scripts_dir.is_dir():
+        return []
+    commands: list[ProjectCommand] = []
+    for script in sorted(scripts_dir.glob("*.sh")):
+        stem = script.stem
+        if not _safe_name(stem):
+            continue
+        commands.append(ProjectCommand(
+            label=f"script: {stem}",
+            command=f"bash scripts/{script.name}",
+            group=_classify_group(stem),
+        ))
+    return commands
+
+
+_GOOSE_TITLE_RE = re.compile(r"^title:\s*['\"]?(.+?)['\"]?\s*$", re.MULTILINE)
+_GOOSE_SKIP_STEMS = frozenset({"SETUP-REQUIRED", "AGENTS"})
+_GOOSE_PRESENTATION = {"reveal": "always", "panel": "dedicated", "focus": True}
+
+
+def _from_goose_recipes(project_path: Path) -> list[ProjectCommand]:
+    """Discover Goose recipe YAML files and generate launch tasks.
+
+    Each recipe becomes a `Goose: <Title>` task using ``goose run --recipe``.
+    Recipes use ``panel: dedicated`` so Goose's interactive session gets its
+    own terminal rather than sharing the shared output panel.
+    """
+    recipes_dir = project_path / ".goose" / "recipes"
+    if not recipes_dir.is_dir():
+        return []
+    commands: list[ProjectCommand] = []
+    for recipe in sorted(recipes_dir.glob("*.yaml")):
+        stem = recipe.stem
+        if stem in _GOOSE_SKIP_STEMS or not _safe_name(stem):
+            continue
+        label = _goose_label(recipe, stem)
+        commands.append(ProjectCommand(
+            label=f"Goose: {label}",
+            command=f"goose run --recipe .goose/recipes/{recipe.name}",
+            group="none",
+            presentation=_GOOSE_PRESENTATION,
+        ))
+    return commands
+
+
+_SLUG_SPLIT_RE = re.compile(r"[-_ ]+")
+
+
+def _goose_label(recipe: Path, stem: str) -> str:
+    """Extract a human-readable label from a recipe file's ``title:`` field.
+
+    Strips the ``— ProjectName`` suffix that agentteams appends, then normalizes
+    by title-casing each dash/underscore/space-separated word so that slugs like
+    ``team-builder`` become ``Team Builder``.  Falls back to title-casing the
+    file stem when the field is absent or unreadable.
+    """
+    def _title_case(s: str) -> str:
+        return " ".join(w.capitalize() for w in _SLUG_SPLIT_RE.split(s) if w)
+
+    fallback = _title_case(stem)
+    try:
+        header = recipe.read_text(encoding="utf-8")[:500]
+    except (OSError, UnicodeDecodeError):
+        return fallback
+    m = _GOOSE_TITLE_RE.search(header)
+    if not m:
+        return fallback
+    title = m.group(1).strip()
+    if " — " in title:   # em-dash separator: "Orchestrator — Project"
+        title = title.split(" — ")[0].strip()
+    elif " - " in title:
+        title = title.split(" - ")[0].strip()
+    return _title_case(title) if title else fallback
+
+
+# ---------------------------------------------------------------------------
+# agentteams meta-tasks (always included)
+# ---------------------------------------------------------------------------
+
+AGENTTEAMS_META_TASKS: list[dict[str, Any]] = [
+    {
+        "label": "agentteams: update agents",
+        "type": "shell",
+        "command": "agentteams --update --merge",
+        "group": "none",
+        "presentation": {"reveal": "always", "panel": "shared"},
+        "problemMatcher": [],
+        "detail": "AGENTTEAMS",
+    },
+    {
+        "label": "agentteams: dry-run check",
+        "type": "shell",
+        "command": "agentteams --update --dry-run",
+        "group": "none",
+        "presentation": {"reveal": "always", "panel": "shared"},
+        "problemMatcher": [],
+        "detail": "AGENTTEAMS",
+    },
+    {
+        "label": "agentteams: fleet update (all)",
+        "type": "shell",
+        "command": "agentteams --fleet . --fleet-frameworks all --update --merge",
+        "group": "none",
+        "presentation": {"reveal": "always", "panel": "shared"},
+        "problemMatcher": [],
+        "detail": "AGENTTEAMS",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Top-level discovery
+# ---------------------------------------------------------------------------
+
+_DISCOVERERS = (
+    _from_package_json,
+    _from_makefile,
+    _from_pyproject_toml,
+    _from_tox_ini,
+    _from_taskfile,
+    _from_scripts_dir,
+    _from_goose_recipes,
+)
+
+
+def discover_project_commands(project_path: Path) -> list[ProjectCommand]:
+    """Discover runnable commands from project tooling files."""
+    commands: list[ProjectCommand] = []
+    for discoverer in _DISCOVERERS:
+        commands.extend(discoverer(project_path))
+    _assign_group_defaults(commands)
+    return commands
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_tasks_json(commands: list[ProjectCommand]) -> str:
+    """Render a fresh tasks.json string from discovered commands + meta-tasks."""
+    tasks: list[dict[str, Any]] = []
+    seen_labels: set[str] = set()
+
+    for cmd in commands:
+        if cmd.label in seen_labels:
+            continue
+        seen_labels.add(cmd.label)
+        if cmd.group in ("test", "build"):
+            group: Any = {"kind": cmd.group, "isDefault": cmd.is_default}
+        else:
+            group = "none"
+        pres = cmd.presentation if cmd.presentation is not None else {"reveal": "always", "panel": "shared"}
+        tasks.append({
+            "label": cmd.label,
+            "type": "shell",
+            "command": cmd.command,
+            "group": group,
+            "presentation": pres,
+            "problemMatcher": [],
+            "detail": "AGENTTEAMS",
+        })
+
+    for meta in AGENTTEAMS_META_TASKS:
+        if meta["label"] not in seen_labels:
+            tasks.append(meta)
+
+    return json.dumps({"version": "2.0.0", "tasks": tasks}, indent=2, ensure_ascii=False) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Sentinel merge
+# ---------------------------------------------------------------------------
+
+def _try_parse_json(text: str) -> "dict[str, Any] | None":
+    """Return the parsed JSON object, or None if parsing fails."""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    """Strip // line comments from JSONC text for parsing purposes.
+
+    This is a simple heuristic — it strips every ``//`` to end-of-line, including
+    those that might appear inside string values.  For sentinel detection this is
+    acceptable: the only consequence of a false strip is that a task label or
+    command is slightly mangled during parse, which will not affect whether we
+    find ``"detail": "AGENTTEAMS"`` on a task object.
+    """
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def _merge_standard_json(existing: dict[str, Any], new_content: str) -> str:
+    """Sentinel merge for well-formed JSON files."""
+    user_tasks = [
+        t for t in (existing.get("tasks") or [])
+        if isinstance(t, dict) and t.get("detail") != "AGENTTEAMS"
+    ]
+    new_tasks: list[dict[str, Any]] = json.loads(new_content).get("tasks", [])
+    new_labels = {t["label"] for t in new_tasks}
+    user_tasks = [t for t in user_tasks if t.get("label") not in new_labels]
+    merged = {"version": "2.0.0", "tasks": user_tasks + new_tasks}
+    return json.dumps(merged, indent=2, ensure_ascii=False) + "\n"
+
+
+def _merge_jsonc(existing: dict[str, Any], raw: str, new_content: str) -> str:
+    """Append new AGENTTEAMS tasks to a JSONC file, preserving original structure.
+
+    Rather than re-serialising (which would destroy comments, ``inputs`` blocks,
+    and hand-crafted formatting), this function splices the new task JSON into the
+    raw file string immediately before the closing ``]`` of the tasks array.
+
+    On the second run the file is parsed again (with comments stripped), the
+    sentinel labels are found, and ``tasks_to_add`` is empty — so the raw string
+    is returned unchanged (idempotent).
+    """
+    existing_tasks = existing.get("tasks") or []
+    existing_sentinel_labels = {
+        t.get("label") for t in existing_tasks
+        if isinstance(t, dict) and t.get("detail") == "AGENTTEAMS"
+    }
+    new_tasks: list[dict[str, Any]] = json.loads(new_content).get("tasks", [])
+    tasks_to_add = [t for t in new_tasks if t["label"] not in existing_sentinel_labels]
+
+    if not tasks_to_add:
+        return raw  # Already up to date.
+
+    # Format each new task with 4-space indent to match the VS Code JSONC convention
+    # used in hand-crafted tasks.json files.
+    chunks: list[str] = []
+    for task in tasks_to_add:
+        task_str = json.dumps(task, indent=2, ensure_ascii=False)
+        indented = "\n".join("    " + line for line in task_str.splitlines())
+        chunks.append(indented)
+
+    insertion = ",\n\n" + ",\n\n".join(chunks)
+
+    # Splice before the last `]` in the file.  For any well-structured tasks.json
+    # the last `]` is the one that closes the tasks array (it comes after the final
+    # task object and before the outer `}`).
+    close_pos = raw.rfind("]")
+    if close_pos == -1:
+        return raw  # Structure not recognised — leave untouched.
+
+    before = raw[:close_pos].rstrip()
+    after = raw[close_pos:].lstrip()       # starts with `]`
+    return before + "\n" + insertion + "\n\n  " + after
+
+
+def sentinel_merge(existing_path: Path, new_content: str) -> str:
+    """Merge new AGENTTEAMS tasks into an existing tasks.json, preserving user tasks.
+
+    Handles both standard JSON and JSONC (VS Code's JSON-with-comments format).
+    For JSONC files the tasks are appended to the raw file, keeping comments, the
+    ``inputs`` block, and hand-crafted formatting intact.
+
+    Raises ValueError with a descriptive message only if the file cannot be parsed
+    even after comment-stripping — never silently overwrites hand-crafted content.
+    """
+    if not existing_path.is_file():
+        return new_content
+    try:
+        raw = existing_path.read_text(encoding="utf-8")
+    except OSError:
+        return new_content
+
+    # --- Standard JSON path ---
+    existing = _try_parse_json(raw)
+    if existing is not None:
+        return _merge_standard_json(existing, new_content)
+
+    # --- JSONC path (JSON with // or /* comments) ---
+    if "//" in raw or "/*" in raw:
+        stripped = _strip_jsonc_comments(raw)
+        jsonc_parsed = _try_parse_json(stripped)
+        if jsonc_parsed is not None:
+            return _merge_jsonc(jsonc_parsed, raw, new_content)
+        try:
+            json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{existing_path} uses JSONC but could not be parsed even after "
+                f"stripping comments: {exc}\n"
+                f"  Fix the file manually or pass --no-vscode-tasks to suppress."
+            ) from exc
+
+    # --- Genuinely corrupt JSON (no comment markers) ---
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{existing_path} contains invalid JSON and cannot be safely merged: {exc}\n"
+            f"  Fix the file manually or delete it and re-run agentteams to regenerate."
+        ) from exc
+
+    return new_content  # unreachable, satisfies type checkers

--- a/build_team.py
+++ b/build_team.py
@@ -102,6 +102,8 @@ from agentteams.cli.commands import (
     _run_convert,
     _run_interop,
     _run_bridge,
+    _run_stale_check,
+    _run_stale_restore,
 )
 # Render/merge helpers extracted to agentteams/cli/render_pipeline.py (CH-07);
 # re-exported so main and tests resolve them in build_team's namespace.

--- a/docs_src/stale-detection-guide.md
+++ b/docs_src/stale-detection-guide.md
@@ -1,0 +1,135 @@
+# Detecting Stale Docs & Scripts (`--stale-check`)
+
+`agentteams --stale-check` is a **read-only** scan that flags stale agent
+documentation and stale code/scripts in a repository. It never edits files. The
+companion `--stale-remediate` prints a *suggested* remediation plan (still no writes).
+
+```bash
+# Scan the current repo (or pass --output / --project to point elsewhere)
+agentteams --stale-check
+
+# Also print a guided remediation plan
+agentteams --stale-check --stale-remediate
+
+# Skip the git-history signal (hermetic / CI / non-git targets)
+agentteams --stale-check --stale-no-git
+```
+
+The exit code **is** the verdict: `0` when clean, `1` when any **Tier-1 (blocking)**
+finding is present.
+
+## What it detects, by reliability tier
+
+Findings are ranked by how confidently the signal implies staleness — and the tier
+governs what action is safe.
+
+| Tier | Code | Meaning |
+|---|---|---|
+| **1 — blocking** | `VCS_CONFLICT_MARKER` | A complete, ordered git merge-conflict triad (`<<<<<<< … ======= … >>>>>>>`). Setext underlines and fenced example blocks are excluded. |
+| **1 — blocking** | `BROKEN_REF` | A markdown-link target that resolves to no file on disk. |
+| **1 — blocking** | `INTEGRITY` | A generated file is `FENCE-BROKEN` / `TRUNCATED` / `MISSING` (reuses the `--verify-integrity` check for every discovered `build-log.json`). |
+| **1 — blocking** | `SOURCE_DRIFT` | A bridge's source agents diverged from the recorded manifest snapshot (only when the source is present on this machine). |
+| **2 — advisory** | `STALE_VS_CODE` | Referenced code changed in a commit **after** the doc's last commit (substantive, whitespace-filtered diff). The doc *may* describe outdated behavior. |
+| **2 — advisory** | `BROKEN_REF` | An inline-code path or an anchored reference (`file.py#L10`) that does not resolve. |
+| **0 — info** | `PROVENANCE_ABSENT` | No build-log / bridge manifest found — generated-file integrity can't be verified. |
+| **0 — info** | `BRIDGE_SOURCE_UNAVAILABLE` | A bridged consumer repo whose `source_dir` is not present here; run `--bridge-check` where the source lives. |
+
+## How freshness is judged from git history
+
+The `STALE_VS_CODE` signal uses commit history, not file mtimes (which a checkout
+resets). For each doc that references code, it asks: *did the referenced file change in
+any commit strictly after the doc's last commit, with a substantive diff?* This is
+deliberately **advisory** — a recent code commit is a suspicion, not proof, so it never
+triggers an automatic edit. The scan **self-disables** the git signal on:
+
+- non-git targets (`recency: unavailable:non-git`),
+- shallow clones (`unavailable:shallow`) — commit times are unreliable there,
+- paths with uncommitted changes (an in-progress fix would otherwise false-positive).
+
+A revert or cherry-pick that restores the documented content is filtered out, because
+the whitespace-filtered diff against the doc's commit comes back empty.
+
+## What it scans
+
+In a git work-tree the file set comes from `git ls-files`, so gitignored trees
+(`tmp/`, backups, local `references/plans/`) are excluded automatically. The
+`examples/`, `workSummaries/`, and `tmp/` directories are always skipped (fixtures /
+archival / scratch). Known live-data / generated files are suppressed from all but
+conflict-marker findings.
+
+## Suppressing known-acceptable findings (`.agentteams-stale-ignore`)
+
+Some "broken" references are intentional — cross-repo links in a dated incident review,
+or files inside a read-only captured package. Put a gitignore-style file named
+`.agentteams-stale-ignore` at the scan root to suppress them:
+
+```
+# cross-repo references in a historical incident review
+docs/aws_ecs_failure_review_2026-04-14.md
+# a read-only verbatim capture package (whole dir)
+docs/canonical-agency-package/
+```
+
+A finding is suppressed when its **referrer file** matches a pattern, or (for a broken
+reference) the **referenced target path** matches. Patterns support an exact path, a
+**directory prefix** (`dir` or `dir/` matches the dir and everything under it), and `*`
+globs. Suppressed findings are **counted and shown** (`suppressed: N`) — never silent.
+
+Two important properties:
+
+- **`VCS_CONFLICT_MARKER` is never suppressible** — a complete conflict triad is always
+  broken, so an ignore pattern can't hide it (even if it matches that file).
+- **Suppression can change the exit code.** Dropping a Tier-1 `BROKEN_REF` removes a
+  blocking finding, so a previously-`1` exit becomes `0`. CI authors: a passing
+  `--stale-check` may reflect entries in `.agentteams-stale-ignore`.
+
+Precedence: the always-skipped trees (`examples/`/`workSummaries/`/`tmp/` and gitignored
+files) are pruned *before* scanning, so an ignore entry can only suppress findings that
+were actually produced — it can't "un-skip" those trees.
+
+## Remediation & revision
+
+`--stale-remediate` (without `--yes`) is a **preview** — it prints, per actionable
+finding, the safe next step and writes nothing.
+
+Adding **`--yes`** promotes it into an **applied, backup-protected revision pass**:
+
+```bash
+agentteams --stale-check --stale-remediate            # preview (no writes)
+agentteams --stale-check --stale-remediate --yes      # apply safe revisions
+agentteams --stale-restore                            # recover the latest snapshot
+```
+
+Before touching anything, the revision pass writes a **sha256-verified safety snapshot**
+of every file it will modify to `.agentteams-backups/stale-fix-<timestamp>/`. Then it
+performs only safe, deterministic revisions:
+
+- `BROKEN_REF` → **repaired** when the missing target has exactly one relocated match
+  (a moved file), by rewriting the link — **never** inside a fenced or USER-EDITABLE
+  region. With no unambiguous target it stays manual.
+- `SOURCE_DRIFT` → **re-merged** via the canonical fence-aware `--bridge-merge` writer
+  (never `--bridge-refresh`).
+- `INTEGRITY` → **routed**: the exact `agentteams --update --merge …` command is printed,
+  not auto-run (it needs the brief and could rewrite the whole team).
+- `VCS_CONFLICT_MARKER` → **manual only**; conflict markers are never auto-resolved.
+
+Exit `3` signals "revision applied, but blocking items still need manual/routed handling."
+
+### Recovery (safety protocol)
+
+If a revision goes wrong, recover from the snapshot:
+
+```bash
+agentteams --stale-restore            # restore the latest stale-fix snapshot
+agentteams --stale-restore 20260619-161940   # or a specific snapshot
+```
+
+`--stale-restore` verifies each backup's sha256 before writing and refuses (writing
+nothing) if a backup is corrupt — a fail-safe restore. In a git work-tree, `git checkout`
+remains an additional backstop.
+
+> **Tip:** ensure `.agentteams-backups/` is gitignored in the target repo so snapshots
+> aren't accidentally committed.
+
+> Methods report, implementation plan, and the adversarial + conflict audits that
+> shaped this feature live under `references/plans/stale-detector-*` in the source repo.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Security Hardening & Threat Intelligence: security-hardening-guide.md
       - Section Fencing & Safe Merges: section-fencing-guide.md
       - Update Lifecycle, Drift & Backups: update-lifecycle-guide.md
+      - Detecting Stale Docs & Scripts: stale-detection-guide.md
       - Update Compatibility Maintenance: update-compatibility-maintenance-guide.md
       - Delivery Procedure: delivery-procedure.md
       - Migration Guide: migration-guide.md

--- a/tests/test_frameworks.py
+++ b/tests/test_frameworks.py
@@ -101,6 +101,9 @@ class TestCopilotVSCodeAdapter:
     def test_supports_handoffs(self):
         assert self.adapter.supports_handoffs() is True
 
+    def test_vscode_tasks_rel_path(self):
+        assert self.adapter.vscode_tasks_rel_path() == "../../.vscode/tasks.json"
+
     def test_get_file_extension_agent(self):
         assert self.adapter.get_file_extension("agent") == ".agent.md"
 
@@ -361,6 +364,9 @@ class TestCopilotCLIAdapter:
     def test_supports_handoffs(self):
         assert self.adapter.supports_handoffs() is False
 
+    def test_vscode_tasks_rel_path(self):
+        assert self.adapter.vscode_tasks_rel_path() is None
+
     def test_handoff_delivery_mode(self):
         assert self.adapter.handoff_delivery_mode() == "manifest"
 
@@ -445,6 +451,9 @@ class TestClaudeAdapter:
 
     def test_supports_handoffs(self):
         assert self.adapter.supports_handoffs() is False
+
+    def test_vscode_tasks_rel_path(self):
+        assert self.adapter.vscode_tasks_rel_path() == "../../.vscode/tasks.json"
 
     def test_handoff_delivery_mode(self):
         assert self.adapter.handoff_delivery_mode() == "manifest"
@@ -724,6 +733,9 @@ class TestGooseAdapter:
 
     def test_supports_handoffs(self):
         assert self.adapter.supports_handoffs() is True
+
+    def test_vscode_tasks_rel_path(self):
+        assert self.adapter.vscode_tasks_rel_path() == "../../.vscode/tasks.json"
 
     def test_handoff_delivery_mode_native(self):
         # Handoffs are encoded into recipes, not a sidecar manifest.

--- a/tests/test_stale_detector.py
+++ b/tests/test_stale_detector.py
@@ -1,0 +1,563 @@
+"""
+Tests for agentteams/stale_detector.py — conflict markers, broken references,
+git-recency, provenance, aggregation/exit codes, and CLI wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agentteams import stale_detector as sd
+from agentteams import stale_remediate as sr
+from agentteams.cli.app import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t.t")
+    _git(path, "config", "user.name", "t")
+    _git(path, "config", "commit.gpgsign", "false")
+
+
+def _commit(path: Path, msg: str) -> None:
+    _git(path, "add", "-A")
+    _git(path, "-c", "core.hooksPath=/dev/null", "commit", "-q", "--no-verify", "-m", msg)
+
+
+class _FakeGit:
+    """Delegates to real git but forces the shallow query to a fixed answer."""
+
+    def __init__(self, shallow: bool):
+        self._shallow = "true" if shallow else "false"
+
+    def __call__(self, repo, *args):
+        if args[:2] == ("rev-parse", "--is-shallow-repository"):
+            return subprocess.CompletedProcess(args, 0, stdout=self._shallow + "\n", stderr="")
+        return _git(repo, *args)
+
+
+# ---------------------------------------------------------------------------
+# Conflict markers (T1a)
+# ---------------------------------------------------------------------------
+
+class TestConflictMarkers:
+    def test_detects_full_triad(self):
+        text = "ok\n<<<<<<< HEAD\nmine\n=======\ntheirs\n>>>>>>> branch\ndone\n"
+        f = sd.detect_conflict_markers(text, "x.md")
+        assert len(f) == 1
+        assert f[0].code == "VCS_CONFLICT_MARKER"
+        assert f[0].tier == 1
+        assert f[0].line == 2
+
+    def test_ignores_setext_underline(self):
+        text = "Heading\n=======\nbody text\n"
+        assert sd.detect_conflict_markers(text, "x.md") == []
+
+    def test_ignores_triad_inside_fenced_block(self):
+        text = "```\n<<<<<<< HEAD\na\n=======\nb\n>>>>>>> z\n```\n"
+        assert sd.detect_conflict_markers(text, "x.md") == []
+
+    def test_ignores_prose_about_conflicts(self):
+        text = "To resolve, delete the <<<<<<< and >>>>>>> lines.\n"
+        assert sd.detect_conflict_markers(text, "x.md") == []
+
+    def test_detects_diff3_style_with_pipes(self):
+        text = "<<<<<<< HEAD\na\n||||||| base\no\n=======\nb\n>>>>>>> x\n"
+        f = sd.detect_conflict_markers(text, "x.md")
+        assert len(f) == 1
+
+
+# ---------------------------------------------------------------------------
+# Reference extraction & suppression (T1b inputs)
+# ---------------------------------------------------------------------------
+
+class TestReferences:
+    def test_extracts_md_link_only(self):
+        # Markdown links are references; inline-code mentions are NOT (too noisy).
+        text = "See [a](src/a.py) and `lib/b.py`.\n"
+        refs = sd.extract_references(text)
+        paths = {(r.path, r.kind) for r in refs}
+        assert ("src/a.py", "md_link") in paths
+        assert not any(r.path == "lib/b.py" for r in refs)
+
+    @pytest.mark.parametrize("token", [
+        "https://example.com/x.py",
+        "//host/x.py",
+        "{PLACEHOLDER}.py",
+        "src/<repo>/x.py",
+        "src/*.py",
+        "/Users/me/abs/x.py",
+        ".github/agents/",
+        "#section",
+    ])
+    def test_suppresses_non_paths(self, token):
+        text = f"[link]({token})\n"
+        assert sd.extract_references(text) == []
+
+    def test_splits_anchor_and_line(self):
+        refs = sd.extract_references("[a](src/a.py#L10) [b](src/b.py:42)\n")
+        by_path = {r.path: r.anchor for r in refs}
+        assert by_path["src/a.py"] == "L10"
+        assert by_path["src/b.py"] == "42"
+
+    def test_ignores_refs_in_fenced_code(self):
+        text = "```\n[x](missing/zzz.py)\n```\n"
+        assert sd.extract_references(text) == []
+
+
+# ---------------------------------------------------------------------------
+# Broken references (T1b)
+# ---------------------------------------------------------------------------
+
+class TestBrokenRefs:
+    def test_missing_md_link_is_tier1(self, tmp_path):
+        doc = tmp_path / "doc.md"
+        doc.write_text("[gone](nope.py)\n")
+        f = sd.detect_broken_refs(doc.read_text(), doc, tmp_path)
+        assert len(f) == 1 and f[0].tier == 1 and f[0].code == "BROKEN_REF"
+
+    def test_resolvable_ref_no_finding(self, tmp_path):
+        (tmp_path / "real.py").write_text("x=1\n")
+        doc = tmp_path / "doc.md"
+        doc.write_text("[ok](real.py)\n")
+        assert sd.detect_broken_refs(doc.read_text(), doc, tmp_path) == []
+
+    def test_anchored_md_link_is_tier2(self, tmp_path):
+        doc = tmp_path / "doc.md"
+        doc.write_text("[a](gone.py#L3)\n")
+        f = sd.detect_broken_refs(doc.read_text(), doc, tmp_path)
+        assert len(f) == 1 and f[0].tier == 2
+
+    def test_inline_code_path_not_flagged(self, tmp_path):
+        # Inline-code paths are intentionally not treated as references.
+        doc = tmp_path / "doc.md"
+        doc.write_text("the module `missing/lib.py` is gone\n")
+        assert sd.detect_broken_refs(doc.read_text(), doc, tmp_path) == []
+
+    def test_resolves_relative_to_doc_dir(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "sib.py").write_text("y=2\n")
+        doc = sub / "doc.md"
+        doc.write_text("[s](sib.py)\n")
+        assert sd.detect_broken_refs(doc.read_text(), doc, tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Git recency (T2a)
+# ---------------------------------------------------------------------------
+
+class TestGitRecency:
+    def _seed(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("[h](helper.py)\n")
+        (tmp_path / "helper.py").write_text('print("v1")\n')
+        _commit(tmp_path, "init")
+
+    def test_flags_code_changed_after_doc(self, tmp_path):
+        self._seed(tmp_path)
+        (tmp_path / "helper.py").write_text('print("v2 substantially different")\n')
+        _commit(tmp_path, "change code")
+        findings, status = sd.detect_git_recency(tmp_path, {"doc.md": {"helper.py"}})
+        assert status == "ok"
+        assert any(f.code == "STALE_VS_CODE" and f.tier == 2 for f in findings)
+
+    def test_revert_to_identical_not_flagged(self, tmp_path):
+        self._seed(tmp_path)
+        (tmp_path / "helper.py").write_text('print("v2")\n')
+        _commit(tmp_path, "change")
+        (tmp_path / "helper.py").write_text('print("v1")\n')  # reverted to doc-era content
+        _commit(tmp_path, "revert")
+        findings, _ = sd.detect_git_recency(tmp_path, {"doc.md": {"helper.py"}})
+        assert not findings
+
+    def test_shallow_self_disables(self, tmp_path):
+        self._seed(tmp_path)
+        findings, status = sd.detect_git_recency(
+            tmp_path, {"doc.md": {"helper.py"}}, git=_FakeGit(shallow=True)
+        )
+        assert status == "unavailable:shallow" and findings == []
+
+    def test_non_git_self_disables(self, tmp_path):
+        (tmp_path / "doc.md").write_text("x\n")
+        findings, status = sd.detect_git_recency(tmp_path, {"doc.md": {"helper.py"}})
+        assert status == "unavailable:non-git" and findings == []
+
+    def test_uncommitted_doc_suppressed(self, tmp_path):
+        self._seed(tmp_path)
+        (tmp_path / "helper.py").write_text('print("v2 different")\n')
+        _commit(tmp_path, "change code")
+        (tmp_path / "doc.md").write_text("[h](helper.py)\n\nedited but not committed\n")
+        findings, _ = sd.detect_git_recency(tmp_path, {"doc.md": {"helper.py"}})
+        assert not findings
+
+
+# ---------------------------------------------------------------------------
+# Provenance (T1c/T1d)
+# ---------------------------------------------------------------------------
+
+class TestProvenance:
+    def test_no_provenance_yields_info(self, tmp_path):
+        (tmp_path / "doc.md").write_text("hi\n")
+        f = sd.detect_provenance(tmp_path)
+        assert len(f) == 1 and f[0].code == "PROVENANCE_ABSENT" and f[0].tier == 0
+
+    def test_missing_recorded_file_is_integrity_tier1(self, tmp_path):
+        agents = tmp_path / ".github" / "agents"
+        refs = agents / "references"
+        refs.mkdir(parents=True)
+        # build-log records a file hash for a file that does not exist -> MISSING
+        (refs / "build-log.json").write_text(json.dumps({
+            "file_hashes": {"orchestrator.agent.md": "deadbeefdeadbeef"},
+        }))
+        f = sd.detect_integrity(tmp_path)
+        assert any(x.code == "INTEGRITY" and x.tier == 1 for x in f)
+
+    def test_bridge_source_absent_yields_info(self, tmp_path):
+        pair = tmp_path / "references" / "bridges" / "copilot-vscode-to-claude"
+        pair.mkdir(parents=True)
+        (pair / "bridge-manifest.json").write_text(json.dumps({
+            "source_dir": str(tmp_path / "does-not-exist"),
+            "source_hashes": [],
+        }))
+        f = sd.detect_bridge_drift(tmp_path)
+        assert len(f) == 1 and f[0].code == "BRIDGE_SOURCE_UNAVAILABLE" and f[0].tier == 0
+
+
+# ---------------------------------------------------------------------------
+# Aggregation, exit code, scan-set
+# ---------------------------------------------------------------------------
+
+class TestScanAndExit:
+    def test_clean_tree_exit_zero(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("# clean\nNo refs here.\n")
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        assert not report.has_blocking
+        assert sd.exit_code(report) == 0
+
+    def test_conflict_triad_exit_one(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "c.md").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> x\n")
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        assert report.has_blocking and sd.exit_code(report) == 1
+
+    def test_examples_and_gitignored_not_scanned(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / ".gitignore").write_text("ignored/\n")
+        (tmp_path / "keep.md").write_text("# keep\n")
+        ex = tmp_path / "examples" / "expected"
+        ex.mkdir(parents=True)
+        (ex / "bad.md").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> x\n")
+        ig = tmp_path / "ignored"
+        ig.mkdir()
+        (ig / "also.md").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> x\n")
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        scanned = {f.file for f in report.findings}
+        assert not any(s.startswith("examples/") for s in scanned)
+        assert not any(s.startswith("ignored/") for s in scanned)
+        assert not report.has_blocking  # the only triads were in skipped trees
+
+    def test_end_to_end_recency_via_aggregator(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("[h](helper.py)\n")
+        (tmp_path / "helper.py").write_text('print("v1")\n')
+        _commit(tmp_path, "init")
+        (tmp_path / "helper.py").write_text('print("v2 quite different now")\n')
+        _commit(tmp_path, "change")
+        report = sd.scan_staleness(tmp_path)
+        assert any(f.code == "STALE_VS_CODE" for f in report.findings)
+
+    def test_remediation_plan_rows(self, tmp_path):
+        report = sd.StalenessReport(root=str(tmp_path))
+        report.findings = [
+            sd.StalenessFinding(1, "VCS_CONFLICT_MARKER", "c.md", 1, "s", "d", "a", False),
+            sd.StalenessFinding(1, "INTEGRITY", "o.md", 0, "s",
+                                "d", "re-run `agentteams --update --merge`", True),
+        ]
+        plan = sd.build_remediation_plan(report)
+        codes = {r["code"]: r for r in plan}
+        assert codes["VCS_CONFLICT_MARKER"]["action"] == "manual"
+        assert codes["INTEGRITY"]["action"] == "run-safe-writer"
+        assert "update --merge" in codes["INTEGRITY"]["command"]
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+class TestCliWiring:
+    def test_clean_returns_zero(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("# clean\n")
+        _commit(tmp_path, "init")
+        assert main(["--stale-check", "--output", str(tmp_path)]) == 0
+
+    def test_blocking_returns_one(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "c.md").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> x\n")
+        _commit(tmp_path, "init")
+        assert main(["--stale-check", "--output", str(tmp_path)]) == 1
+
+    def test_remediate_requires_check(self, tmp_path):
+        with pytest.raises(SystemExit):
+            main(["--stale-remediate", "--output", str(tmp_path)])
+
+    def test_mutually_exclusive_with_verify_integrity(self, tmp_path):
+        with pytest.raises(SystemExit):
+            main(["--stale-check", "--verify-integrity", "--output", str(tmp_path)])
+
+    def test_stale_restore_without_snapshot_errors(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("# x\n")
+        _commit(tmp_path, "init")
+        assert main(["--stale-restore", "--output", str(tmp_path)]) == 1
+
+    def test_no_git_skips_recency(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("[h](helper.py)\n")
+        (tmp_path / "helper.py").write_text('print("v1")\n')
+        _commit(tmp_path, "init")
+        (tmp_path / "helper.py").write_text('print("v2 different")\n')
+        _commit(tmp_path, "change")
+        report = sd.scan_staleness(tmp_path, include_git=False)
+        assert report.recency_status == "disabled"
+        assert not any(f.code == "STALE_VS_CODE" for f in report.findings)
+
+
+# ---------------------------------------------------------------------------
+# Revision phase: snapshot / restore safety protocol
+# ---------------------------------------------------------------------------
+
+class TestSnapshotRestore:
+    def test_snapshot_then_restore_byte_identical(self, tmp_path):
+        f = tmp_path / "a.md"
+        original = "line1\nline2\n"
+        f.write_text(original)
+        snap = sr.snapshot_files(tmp_path, ["a.md"], stamp="20260619-000000")
+        assert snap is not None and (snap / "manifest.json").is_file()
+        # Simulate a buggy revision corrupting the file mid-debug.
+        f.write_text("CORRUPTED GARBAGE")
+        restored = sr.restore_snapshot(tmp_path, snap)
+        assert restored == ["a.md"]
+        assert f.read_text() == original  # recovered exactly
+
+    def test_snapshot_empty_when_no_files(self, tmp_path):
+        assert sr.snapshot_files(tmp_path, ["missing.md"]) is None
+
+    def test_restore_rejects_corrupt_backup(self, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("hi\n")
+        snap = sr.snapshot_files(tmp_path, ["a.md"], stamp="20260619-000001")
+        # Tamper with the backup copy → sha256 mismatch → restore must refuse (fail-safe).
+        (snap / "files" / "a.md").write_text("tampered")
+        f.write_text("current")
+        with pytest.raises(ValueError):
+            sr.restore_snapshot(tmp_path, snap)
+        assert f.read_text() == "current"  # nothing written on a corrupt snapshot
+
+    def test_latest_snapshot_picks_newest(self, tmp_path):
+        (tmp_path / "a.md").write_text("x\n")
+        sr.snapshot_files(tmp_path, ["a.md"], stamp="20260619-000000")
+        newest = sr.snapshot_files(tmp_path, ["a.md"], stamp="20260619-235959")
+        assert sr.latest_snapshot(tmp_path) == newest
+
+
+# ---------------------------------------------------------------------------
+# Revision phase: broken-reference repair + apply_fixes
+# ---------------------------------------------------------------------------
+
+class TestRefRepair:
+    def _repo_with_moved_file(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "new").mkdir()
+        (tmp_path / "new" / "helper.py").write_text("x=1\n")
+        # doc links the OLD location (file actually lives in new/)
+        (tmp_path / "doc.md").write_text("See [helper](old/helper.py).\n")
+        _commit(tmp_path, "init")
+        return tmp_path
+
+    def test_dry_run_plans_but_writes_nothing(self, tmp_path):
+        self._repo_with_moved_file(tmp_path)
+        before = (tmp_path / "doc.md").read_text()
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=False)
+        assert any(a.code == "BROKEN_REF" and not a.applied for a in result.actions)
+        assert result.snapshot_dir is None
+        assert (tmp_path / "doc.md").read_text() == before  # unchanged
+
+    def test_apply_repairs_and_snapshots(self, tmp_path):
+        self._repo_with_moved_file(tmp_path)
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=True)
+        assert result.snapshot_dir is not None
+        assert any(a.action == "repaired-ref" and a.applied for a in result.actions)
+        assert "](new/helper.py)" in (tmp_path / "doc.md").read_text()
+        # re-scan: the broken ref is gone
+        assert not any(f.code == "BROKEN_REF" for f in sd.scan_staleness(tmp_path).findings)
+
+    def test_apply_then_restore_recovers(self, tmp_path):
+        self._repo_with_moved_file(tmp_path)
+        original = (tmp_path / "doc.md").read_text()
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=True)
+        sr.restore_snapshot(tmp_path, Path(result.snapshot_dir))
+        assert (tmp_path / "doc.md").read_text() == original
+
+    def test_fenced_file_not_auto_edited(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "new").mkdir()
+        (tmp_path / "new" / "helper.py").write_text("x=1\n")
+        (tmp_path / "doc.md").write_text(
+            "<!-- AGENTTEAMS:BEGIN body v=1 -->\n[helper](old/helper.py)\n"
+            "<!-- AGENTTEAMS:END body -->\n"
+        )
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=True)
+        # broken ref present but the fenced file is routed to manual, not auto-edited
+        assert any(a.code == "BROKEN_REF" and a.action == "manual" for a in result.actions)
+        assert "old/helper.py" in (tmp_path / "doc.md").read_text()
+
+    def test_no_unambiguous_target_is_manual(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("[gone](does/not/exist.py)\n")
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=True)
+        assert any(a.code == "BROKEN_REF" and a.action == "manual" for a in result.actions)
+
+
+class TestRevisionCli:
+    def _repo(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / "new").mkdir()
+        (tmp_path / "new" / "helper.py").write_text("x=1\n")
+        (tmp_path / "doc.md").write_text("[helper](old/helper.py)\n")
+        _commit(tmp_path, "init")
+
+    def test_remediate_preview_writes_nothing(self, tmp_path):
+        self._repo(tmp_path)
+        before = (tmp_path / "doc.md").read_text()
+        rc = main(["--stale-check", "--stale-remediate", "--output", str(tmp_path)])
+        assert rc == 1  # blocking broken ref still present (preview only)
+        assert (tmp_path / "doc.md").read_text() == before
+
+    def test_remediate_yes_applies_then_restore(self, tmp_path):
+        self._repo(tmp_path)
+        original = (tmp_path / "doc.md").read_text()
+        rc = main(["--stale-check", "--stale-remediate", "--yes", "--output", str(tmp_path)])
+        assert rc in (0, 3)
+        assert "](new/helper.py)" in (tmp_path / "doc.md").read_text()
+        # recover via the CLI restore path
+        assert main(["--stale-restore", "--output", str(tmp_path)]) == 0
+        assert (tmp_path / "doc.md").read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# F1 — .agentteams-stale-ignore suppression
+# ---------------------------------------------------------------------------
+
+class TestStaleIgnore:
+    def _repo(self, tmp_path, ignore_lines):
+        _init_repo(tmp_path)
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "incident.md").write_text("see [x](src/gone.py)\n")
+        (tmp_path / "c.md").write_text("<<<<<<< HEAD\na\n=======\nb\n>>>>>>> x\n")
+        if ignore_lines is not None:
+            (tmp_path / ".agentteams-stale-ignore").write_text(ignore_lines)
+        _commit(tmp_path, "init")
+        return sd.scan_staleness(tmp_path)
+
+    def test_referrer_file_pattern_suppresses_broken_ref(self, tmp_path):
+        r = self._repo(tmp_path, "docs/incident.md\n")
+        assert r.suppressed_count == 1
+        assert not any(f.code == "BROKEN_REF" for f in r.findings)
+
+    def test_dir_prefix_pattern_suppresses(self, tmp_path):
+        r = self._repo(tmp_path, "docs/\n")   # trailing-slash dir prefix (NOT bare fnmatch)
+        assert not any(f.code == "BROKEN_REF" for f in r.findings)
+
+    def test_target_pattern_suppresses(self, tmp_path):
+        r = self._repo(tmp_path, "src/gone.py\n")  # match the reference target, not the referrer
+        assert not any(f.code == "BROKEN_REF" for f in r.findings)
+
+    def test_conflict_marker_never_suppressed(self, tmp_path):
+        # A pattern matching c.md must NOT drop its conflict triad.
+        r = self._repo(tmp_path, "c.md\ndocs/incident.md\n")
+        assert any(f.code == "VCS_CONFLICT_MARKER" for f in r.findings)
+        assert not any(f.code == "BROKEN_REF" for f in r.findings)
+
+    def test_comments_and_blanks_ignored(self, tmp_path):
+        r = self._repo(tmp_path, "# a comment\n\nsrc/gone.py\n")
+        assert not any(f.code == "BROKEN_REF" for f in r.findings)
+
+    def test_no_ignore_file_no_change(self, tmp_path):
+        r = self._repo(tmp_path, None)
+        assert r.suppressed_count == 0
+        assert any(f.code == "BROKEN_REF" for f in r.findings)
+
+    def test_suppressed_broken_ref_flips_exit_and_skips_apply(self, tmp_path):
+        # Only the broken ref + a clean tree → suppressing it yields exit 0 and no apply action.
+        _init_repo(tmp_path)
+        (tmp_path / "doc.md").write_text("[x](gone/missing.py)\n")
+        (tmp_path / ".agentteams-stale-ignore").write_text("doc.md\n")
+        _commit(tmp_path, "init")
+        r = sd.scan_staleness(tmp_path)
+        assert sd.exit_code(r) == 0
+        result = sr.apply_fixes(r, tmp_path, apply=False)
+        assert not any(a.code == "BROKEN_REF" for a in result.actions)
+
+
+# ---------------------------------------------------------------------------
+# F2 — backups-not-gitignored guard
+# ---------------------------------------------------------------------------
+
+class TestBackupsGuard:
+    def test_warns_when_not_gitignored(self, tmp_path):
+        # repo with a relocatable broken ref → apply writes a snapshot; .agentteams-backups
+        # is not gitignored → a warning is emitted.
+        _init_repo(tmp_path)
+        (tmp_path / "new").mkdir()
+        (tmp_path / "new" / "helper.py").write_text("x=1\n")
+        (tmp_path / "doc.md").write_text("[h](old/helper.py)\n")
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=True)
+        assert result.snapshot_dir is not None
+        assert any("gitignore" in w for w in result.warnings)
+
+    def test_no_warning_when_gitignored(self, tmp_path):
+        _init_repo(tmp_path)
+        (tmp_path / ".gitignore").write_text(".agentteams-backups/\n")
+        (tmp_path / "new").mkdir()
+        (tmp_path / "new" / "helper.py").write_text("x=1\n")
+        (tmp_path / "doc.md").write_text("[h](old/helper.py)\n")
+        _commit(tmp_path, "init")
+        report = sd.scan_staleness(tmp_path)
+        result = sr.apply_fixes(report, tmp_path, apply=True)
+        assert result.snapshot_dir is not None
+        assert result.warnings == []
+
+    def test_backups_ignored_helper_non_git(self, tmp_path):
+        # non-git target → n/a → treated as ignored (no warning)
+        assert sr._backups_ignored(tmp_path, fleet_git, ".agentteams-backups/x") is True
+
+
+# fleet._git for the helper test
+from agentteams.fleet import _git as fleet_git  # noqa: E402

--- a/tests/test_vscode_tasks.py
+++ b/tests/test_vscode_tasks.py
@@ -1,0 +1,633 @@
+"""
+Tests for agentteams/vscode_tasks.py — task discovery, rendering, and sentinel merge.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentteams.vscode_tasks import (
+    AGENTTEAMS_META_TASKS,
+    ProjectCommand,
+    _assign_group_defaults,
+    _classify_group,
+    _from_goose_recipes,
+    _from_makefile,
+    _from_package_json,
+    _from_pyproject_toml,
+    _from_scripts_dir,
+    _from_taskfile,
+    _from_tox_ini,
+    _merge_jsonc,
+    _safe_name,
+    _strip_jsonc_comments,
+    discover_project_commands,
+    render_tasks_json,
+    sentinel_merge,
+)
+
+
+# ---------------------------------------------------------------------------
+# _safe_name
+# ---------------------------------------------------------------------------
+
+class TestSafeName:
+    def test_accepts_simple_names(self):
+        assert _safe_name("test")
+        assert _safe_name("build")
+        assert _safe_name("my-task")
+        assert _safe_name("my_task")
+        assert _safe_name("task:build")
+        assert _safe_name("Task 1")
+
+    def test_rejects_shell_metacharacters(self):
+        assert not _safe_name("$(INJECT)")
+        assert not _safe_name("test;rm")
+        assert not _safe_name("../escape")
+        assert not _safe_name("test`whoami`")
+        assert not _safe_name("test && rm")
+        assert not _safe_name("")
+
+    def test_rejects_empty_string(self):
+        assert not _safe_name("")
+
+
+# ---------------------------------------------------------------------------
+# _classify_group
+# ---------------------------------------------------------------------------
+
+class TestClassifyGroup:
+    def test_test_keywords(self):
+        assert _classify_group("test") == "test"
+        assert _classify_group("unit-test") == "test"
+        assert _classify_group("lint") == "test"
+        assert _classify_group("verify") == "test"
+        assert _classify_group("qa") == "test"
+
+    def test_build_keywords(self):
+        assert _classify_group("build") == "build"
+        assert _classify_group("compile") == "build"
+        assert _classify_group("bundle") == "build"
+        assert _classify_group("dist") == "build"
+
+    def test_none_fallback(self):
+        assert _classify_group("deploy") == "none"
+        assert _classify_group("start") == "none"
+        assert _classify_group("clean") == "none"
+
+
+# ---------------------------------------------------------------------------
+# _from_package_json
+# ---------------------------------------------------------------------------
+
+class TestFromPackageJson:
+    def test_extracts_scripts(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"test": "jest", "build": "tsc", "lint": "eslint ."}}),
+            encoding="utf-8",
+        )
+        cmds = _from_package_json(tmp_path)
+        labels = [c.label for c in cmds]
+        assert "npm: test" in labels
+        assert "npm: build" in labels
+        assert "npm: lint" in labels
+
+    def test_classifies_groups_correctly(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"test": "jest", "build": "tsc", "start": "node ."}}),
+            encoding="utf-8",
+        )
+        cmds = _from_package_json(tmp_path)
+        by_label = {c.label: c for c in cmds}
+        assert by_label["npm: test"].group == "test"
+        assert by_label["npm: build"].group == "build"
+        assert by_label["npm: start"].group == "none"
+
+    def test_returns_empty_when_no_file(self, tmp_path):
+        assert _from_package_json(tmp_path) == []
+
+    def test_returns_empty_on_malformed_json(self, tmp_path):
+        (tmp_path / "package.json").write_text("{bad json", encoding="utf-8")
+        assert _from_package_json(tmp_path) == []
+
+    def test_returns_empty_when_no_scripts_key(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"name": "my-project"}), encoding="utf-8"
+        )
+        assert _from_package_json(tmp_path) == []
+
+    def test_skips_unsafe_script_names(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"safe": "echo ok", "$(INJECT)": "evil"}}),
+            encoding="utf-8",
+        )
+        cmds = _from_package_json(tmp_path)
+        labels = [c.label for c in cmds]
+        assert "npm: safe" in labels
+        assert not any("INJECT" in l for l in labels)
+
+
+# ---------------------------------------------------------------------------
+# _from_makefile
+# ---------------------------------------------------------------------------
+
+class TestFromMakefile:
+    def test_extracts_phony_targets(self, tmp_path):
+        (tmp_path / "Makefile").write_text(
+            ".PHONY: test build lint\ntest:\n\tpytest\nbuild:\n\tgcc\n",
+            encoding="utf-8",
+        )
+        cmds = _from_makefile(tmp_path)
+        labels = {c.label for c in cmds}
+        assert labels == {"make: test", "make: build", "make: lint"}
+
+    def test_phony_only_not_all_targets(self, tmp_path):
+        (tmp_path / "Makefile").write_text(
+            ".PHONY: test\ntest:\n\tpytest\nhidden-target:\n\techo hi\n",
+            encoding="utf-8",
+        )
+        cmds = _from_makefile(tmp_path)
+        labels = {c.label for c in cmds}
+        assert labels == {"make: test"}
+        assert "make: hidden-target" not in labels
+
+    def test_rejects_shell_expansion_names(self, tmp_path):
+        (tmp_path / "Makefile").write_text(
+            ".PHONY: test $(DANGEROUS)\n", encoding="utf-8"
+        )
+        cmds = _from_makefile(tmp_path)
+        labels = [c.label for c in cmds]
+        assert labels == ["make: test"]
+
+    def test_returns_empty_when_no_file(self, tmp_path):
+        assert _from_makefile(tmp_path) == []
+
+    def test_classifies_groups(self, tmp_path):
+        (tmp_path / "Makefile").write_text(
+            ".PHONY: test build deploy\n", encoding="utf-8"
+        )
+        cmds = _from_makefile(tmp_path)
+        by_label = {c.label: c for c in cmds}
+        assert by_label["make: test"].group == "test"
+        assert by_label["make: build"].group == "build"
+        assert by_label["make: deploy"].group == "none"
+
+
+# ---------------------------------------------------------------------------
+# _from_pyproject_toml
+# ---------------------------------------------------------------------------
+
+class TestFromPyprojectToml:
+    def test_extracts_taskipy_tasks(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.taskipy.tasks]\ntest = \"pytest tests/ -q\"\nlint = \"ruff check .\"\n",
+            encoding="utf-8",
+        )
+        cmds = _from_pyproject_toml(tmp_path)
+        labels = {c.label for c in cmds}
+        assert labels == {"task: test", "task: lint"}
+
+    def test_extracts_poe_tasks(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.poethepoet.tasks]\ntest = \"pytest\"\n",
+            encoding="utf-8",
+        )
+        cmds = _from_pyproject_toml(tmp_path)
+        assert any(c.label == "task: test" for c in cmds)
+
+    def test_skips_project_scripts_section(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[project.scripts]\nmy-cli = \"mypackage.cli:main\"\n",
+            encoding="utf-8",
+        )
+        cmds = _from_pyproject_toml(tmp_path)
+        assert cmds == []
+
+    def test_returns_empty_when_no_file(self, tmp_path):
+        assert _from_pyproject_toml(tmp_path) == []
+
+    def test_skips_comment_lines(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.taskipy.tasks]\n# this is a comment\ntest = \"pytest\"\n",
+            encoding="utf-8",
+        )
+        cmds = _from_pyproject_toml(tmp_path)
+        assert all(c.label != "task: # this is a comment" for c in cmds)
+        assert any(c.label == "task: test" for c in cmds)
+
+
+# ---------------------------------------------------------------------------
+# _from_tox_ini
+# ---------------------------------------------------------------------------
+
+class TestFromToxIni:
+    def test_extracts_testenv_names(self, tmp_path):
+        (tmp_path / "tox.ini").write_text(
+            "[testenv:test]\ncommands = pytest\n\n[testenv:lint]\ncommands = ruff check .\n",
+            encoding="utf-8",
+        )
+        cmds = _from_tox_ini(tmp_path)
+        labels = {c.label for c in cmds}
+        assert labels == {"tox: test", "tox: lint"}
+
+    def test_all_tox_tasks_classified_as_test(self, tmp_path):
+        (tmp_path / "tox.ini").write_text(
+            "[testenv:build]\ncommands = python -m build\n", encoding="utf-8"
+        )
+        cmds = _from_tox_ini(tmp_path)
+        assert all(c.group == "test" for c in cmds)
+
+    def test_returns_empty_when_no_file(self, tmp_path):
+        assert _from_tox_ini(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# _from_taskfile
+# ---------------------------------------------------------------------------
+
+class TestFromTaskfile:
+    def test_extracts_task_keys_yml(self, tmp_path):
+        (tmp_path / "Taskfile.yml").write_text(
+            "version: '3'\ntasks:\n  test:\n    cmds: [go test ./...]\n  build:\n    cmds: [go build ./...]\n",
+            encoding="utf-8",
+        )
+        cmds = _from_taskfile(tmp_path)
+        labels = {c.label for c in cmds}
+        assert "task: test" in labels
+        assert "task: build" in labels
+
+    def test_skips_reserved_keys(self, tmp_path):
+        (tmp_path / "Taskfile.yml").write_text(
+            "version: '3'\ntasks:\n  test:\n    cmds: [echo]\nvars:\n  FOO: bar\n",
+            encoding="utf-8",
+        )
+        cmds = _from_taskfile(tmp_path)
+        labels = {c.label for c in cmds}
+        assert "task: vars" not in labels
+        assert "task: version" not in labels
+
+    def test_falls_back_to_yaml_extension(self, tmp_path):
+        (tmp_path / "Taskfile.yaml").write_text(
+            "version: '3'\ntasks:\n  deploy:\n    cmds: [echo deploy]\n",
+            encoding="utf-8",
+        )
+        cmds = _from_taskfile(tmp_path)
+        assert any(c.label == "task: deploy" for c in cmds)
+
+    def test_returns_empty_when_no_file(self, tmp_path):
+        assert _from_taskfile(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# _from_scripts_dir
+# ---------------------------------------------------------------------------
+
+class TestFromScriptsDir:
+    def test_extracts_sh_files(self, tmp_path):
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "deploy.sh").write_text("#!/bin/bash\necho deploy\n", encoding="utf-8")
+        (scripts / "test.sh").write_text("#!/bin/bash\npytest\n", encoding="utf-8")
+        cmds = _from_scripts_dir(tmp_path)
+        labels = {c.label for c in cmds}
+        assert labels == {"script: deploy", "script: test"}
+
+    def test_skips_non_sh_files(self, tmp_path):
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "deploy.sh").write_text("echo", encoding="utf-8")
+        (scripts / "helper.py").write_text("print('x')", encoding="utf-8")
+        cmds = _from_scripts_dir(tmp_path)
+        labels = {c.label for c in cmds}
+        assert "script: helper" not in labels
+
+    def test_returns_empty_when_no_scripts_dir(self, tmp_path):
+        assert _from_scripts_dir(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# _assign_group_defaults
+# ---------------------------------------------------------------------------
+
+class TestAssignGroupDefaults:
+    def test_first_test_and_build_become_defaults(self):
+        cmds = [
+            ProjectCommand("npm: test", "npm run test", group="test"),
+            ProjectCommand("npm: test2", "npm run test2", group="test"),
+            ProjectCommand("npm: build", "npm run build", group="build"),
+            ProjectCommand("npm: build2", "npm run build2", group="build"),
+        ]
+        _assign_group_defaults(cmds)
+        assert cmds[0].is_default is True
+        assert cmds[1].is_default is False
+        assert cmds[2].is_default is True
+        assert cmds[3].is_default is False
+
+
+# ---------------------------------------------------------------------------
+# discover_project_commands
+# ---------------------------------------------------------------------------
+
+class TestDiscoverProjectCommands:
+    def test_empty_project_returns_empty(self, tmp_path):
+        assert discover_project_commands(tmp_path) == []
+
+    def test_aggregates_multiple_sources(self, tmp_path):
+        (tmp_path / "package.json").write_text(
+            json.dumps({"scripts": {"test": "jest"}}), encoding="utf-8"
+        )
+        (tmp_path / "tox.ini").write_text("[testenv:lint]\ncommands = ruff\n", encoding="utf-8")
+        cmds = discover_project_commands(tmp_path)
+        labels = {c.label for c in cmds}
+        assert "npm: test" in labels
+        assert "tox: lint" in labels
+
+
+# ---------------------------------------------------------------------------
+# _from_goose_recipes
+# ---------------------------------------------------------------------------
+
+class TestFromGooseRecipes:
+    def _make_recipe(self, path: Path, stem: str, title: str) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        (path / f"{stem}.yaml").write_text(
+            f'version: "1.0.0"\ntitle: "{title}"\ndescription: "test"\n',
+            encoding="utf-8",
+        )
+
+    def test_discovers_recipes(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        self._make_recipe(rd, "orchestrator", "Orchestrator — MyProject")
+        self._make_recipe(rd, "security", "Security — MyProject")
+        cmds = _from_goose_recipes(tmp_path)
+        labels = [c.label for c in cmds]
+        assert "Goose: Orchestrator" in labels
+        assert "Goose: Security" in labels
+
+    def test_strips_project_suffix(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        self._make_recipe(rd, "git-operations", "Git Operations — SomeProject")
+        cmds = _from_goose_recipes(tmp_path)
+        assert cmds[0].label == "Goose: Git Operations"
+
+    def test_command_uses_recipe_path(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        self._make_recipe(rd, "orchestrator", "Orchestrator — X")
+        cmd = _from_goose_recipes(tmp_path)[0]
+        assert cmd.command == "goose run --recipe .goose/recipes/orchestrator.yaml"
+
+    def test_uses_dedicated_panel(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        self._make_recipe(rd, "orchestrator", "Orchestrator — X")
+        cmd = _from_goose_recipes(tmp_path)[0]
+        assert cmd.presentation is not None
+        assert cmd.presentation.get("panel") == "dedicated"
+        assert cmd.presentation.get("focus") is True
+
+    def test_skips_setup_required(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        self._make_recipe(rd, "orchestrator", "Orchestrator — X")
+        self._make_recipe(rd, "SETUP-REQUIRED", "Setup Required — X")
+        cmds = _from_goose_recipes(tmp_path)
+        labels = [c.label for c in cmds]
+        assert not any("SETUP" in l for l in labels)
+
+    def test_falls_back_to_slug_when_no_title(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        rd.mkdir(parents=True)
+        (rd / "my-agent.yaml").write_text("version: '1.0.0'\n", encoding="utf-8")
+        cmds = _from_goose_recipes(tmp_path)
+        assert cmds[0].label == "Goose: My Agent"
+
+    def test_returns_empty_when_no_recipes_dir(self, tmp_path):
+        assert _from_goose_recipes(tmp_path) == []
+
+    def test_goose_tasks_use_dedicated_panel_in_rendered_json(self, tmp_path):
+        rd = tmp_path / ".goose" / "recipes"
+        self._make_recipe(rd, "orchestrator", "Orchestrator — X")
+        cmds = _from_goose_recipes(tmp_path)
+        content = render_tasks_json(cmds)
+        data = json.loads(content)
+        goose_task = next(t for t in data["tasks"] if t["label"] == "Goose: Orchestrator")
+        assert goose_task["presentation"]["panel"] == "dedicated"
+        assert goose_task["presentation"]["focus"] is True
+
+
+# ---------------------------------------------------------------------------
+# render_tasks_json
+# ---------------------------------------------------------------------------
+
+class TestRenderTasksJson:
+    def test_valid_json_output(self):
+        content = render_tasks_json([])
+        data = json.loads(content)
+        assert data["version"] == "2.0.0"
+        assert isinstance(data["tasks"], list)
+
+    def test_all_tasks_have_agentteams_sentinel(self):
+        cmds = [ProjectCommand("npm: test", "npm run test", group="test")]
+        content = render_tasks_json(cmds)
+        data = json.loads(content)
+        assert all(t["detail"] == "AGENTTEAMS" for t in data["tasks"])
+
+    def test_meta_tasks_always_included(self):
+        content = render_tasks_json([])
+        data = json.loads(content)
+        meta_labels = {t["label"] for t in AGENTTEAMS_META_TASKS}
+        output_labels = {t["label"] for t in data["tasks"]}
+        assert meta_labels.issubset(output_labels)
+
+    def test_test_group_uses_object_form(self):
+        cmds = [ProjectCommand("npm: test", "npm run test", group="test", is_default=True)]
+        content = render_tasks_json(cmds)
+        data = json.loads(content)
+        task = next(t for t in data["tasks"] if t["label"] == "npm: test")
+        assert task["group"] == {"kind": "test", "isDefault": True}
+
+    def test_none_group_uses_string_form(self):
+        cmds = [ProjectCommand("npm: start", "npm start", group="none")]
+        content = render_tasks_json(cmds)
+        data = json.loads(content)
+        task = next(t for t in data["tasks"] if t["label"] == "npm: start")
+        assert task["group"] == "none"
+
+    def test_no_duplicate_labels(self):
+        cmds = [
+            ProjectCommand("npm: test", "npm run test", group="test"),
+            ProjectCommand("npm: test", "npm run test", group="test"),
+        ]
+        content = render_tasks_json(cmds)
+        data = json.loads(content)
+        labels = [t["label"] for t in data["tasks"]]
+        assert len(labels) == len(set(labels))
+
+    def test_ends_with_newline(self):
+        assert render_tasks_json([]).endswith("\n")
+
+    def test_meta_tasks_not_duplicated_by_command_list(self):
+        # If a discovered command has the same label as a meta-task, it should appear once
+        meta_label = AGENTTEAMS_META_TASKS[0]["label"]
+        cmds = [ProjectCommand(meta_label, "some-other-cmd", group="none")]
+        content = render_tasks_json(cmds)
+        data = json.loads(content)
+        occurrences = sum(1 for t in data["tasks"] if t["label"] == meta_label)
+        assert occurrences == 1
+
+
+# ---------------------------------------------------------------------------
+# sentinel_merge
+# ---------------------------------------------------------------------------
+
+class TestSentinelMerge:
+    def test_returns_new_content_when_no_existing_file(self, tmp_path):
+        new_content = render_tasks_json([])
+        result = sentinel_merge(tmp_path / "tasks.json", new_content)
+        assert result == new_content
+
+    def test_preserves_user_tasks(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text(
+            json.dumps({"version": "2.0.0", "tasks": [
+                {"label": "my-custom", "type": "shell", "command": "echo hi"},
+            ]}),
+            encoding="utf-8",
+        )
+        new_content = render_tasks_json([])
+        result = sentinel_merge(existing, new_content)
+        data = json.loads(result)
+        labels = {t["label"] for t in data["tasks"]}
+        assert "my-custom" in labels
+
+    def test_replaces_old_agentteams_tasks(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text(
+            json.dumps({"version": "2.0.0", "tasks": [
+                {"label": "agentteams: dry-run check", "type": "shell",
+                 "command": "OLD-COMMAND", "detail": "AGENTTEAMS"},
+            ]}),
+            encoding="utf-8",
+        )
+        new_content = render_tasks_json([])
+        result = sentinel_merge(existing, new_content)
+        data = json.loads(result)
+        dry_run = next(t for t in data["tasks"] if t["label"] == "agentteams: dry-run check")
+        assert dry_run["command"] == "agentteams --update --dry-run"
+
+    def test_user_task_wins_label_collision(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text(
+            json.dumps({"version": "2.0.0", "tasks": [
+                {"label": "npm: test", "type": "shell", "command": "user-version"},
+            ]}),
+            encoding="utf-8",
+        )
+        cmds = [ProjectCommand("npm: test", "npm run test", group="test")]
+        new_content = render_tasks_json(cmds)
+        result = sentinel_merge(existing, new_content)
+        data = json.loads(result)
+        npm_test = next(t for t in data["tasks"] if t["label"] == "npm: test")
+        # Generated version wins (sentinel_merge replaces user task with generated one)
+        assert npm_test["command"] == "npm run test"
+
+    def test_no_duplicate_labels_after_merge(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text(
+            json.dumps({"version": "2.0.0", "tasks": [
+                {"label": "my-task", "type": "shell", "command": "echo"},
+                {"label": "agentteams: dry-run check", "type": "shell",
+                 "command": "old", "detail": "AGENTTEAMS"},
+            ]}),
+            encoding="utf-8",
+        )
+        new_content = render_tasks_json([])
+        result = sentinel_merge(existing, new_content)
+        data = json.loads(result)
+        labels = [t["label"] for t in data["tasks"]]
+        assert len(labels) == len(set(labels))
+
+    def test_raises_on_malformed_json(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text('{"version": "2.0.0", "tasks": [,]}', encoding="utf-8")
+        with pytest.raises(ValueError, match="invalid JSON"):
+            sentinel_merge(existing, render_tasks_json([]))
+
+    def test_jsonc_file_gets_tasks_appended(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text(
+            '{\n  "version": "2.0.0",\n  "tasks": [\n'
+            '    // ── MY TASKS ──\n'
+            '    {\n      "label": "my-task",\n      "type": "shell",\n'
+            '      "command": "echo hi",\n      "problemMatcher": []\n    }\n\n  ]\n}',
+            encoding="utf-8",
+        )
+        new_content = render_tasks_json([])
+        result = sentinel_merge(existing, new_content)
+        # Original comment preserved
+        assert "// ── MY TASKS ──" in result
+        # User task preserved
+        assert '"label": "my-task"' in result
+        # agentteams meta-tasks appended
+        assert '"agentteams: update agents"' in result
+        assert '"detail": "AGENTTEAMS"' in result
+
+    def test_jsonc_append_is_idempotent(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        existing.write_text(
+            '{\n  "version": "2.0.0",\n  "tasks": [\n'
+            '    // comment\n'
+            '    {\n      "label": "my-task",\n      "type": "shell",\n'
+            '      "command": "echo",\n      "problemMatcher": []\n    }\n\n  ]\n}',
+            encoding="utf-8",
+        )
+        new_content = render_tasks_json([])
+        first = sentinel_merge(existing, new_content)
+        # Write result back and merge again
+        existing.write_text(first, encoding="utf-8")
+        second = sentinel_merge(existing, new_content)
+        # Labels should appear exactly once each
+        meta_label = "agentteams: update agents"
+        assert first.count(f'"{meta_label}"') == 1
+        assert second.count(f'"{meta_label}"') == 1
+
+    def test_raises_with_jsonc_unparseable_after_strip(self, tmp_path):
+        existing = tmp_path / "tasks.json"
+        # JSONC that's still invalid even after stripping comments
+        existing.write_text(
+            '{\n  // a comment\n  "version": "2.0.0",\n  "tasks": [,]\n}',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="JSONC but could not be parsed"):
+            sentinel_merge(existing, render_tasks_json([]))
+
+    def test_returns_new_content_on_unreadable_file(self, tmp_path):
+        # Simulate unreadable file by pointing to a directory
+        existing = tmp_path / "tasks.json"
+        existing.mkdir()  # a directory, not a file — is_file() returns False
+        new_content = render_tasks_json([])
+        result = sentinel_merge(existing, new_content)
+        assert result == new_content
+
+
+# ---------------------------------------------------------------------------
+# Adapter vscode_tasks_rel_path() integration (imported from frameworks)
+# ---------------------------------------------------------------------------
+
+class TestAdapterRelPath:
+    def test_copilot_vscode_returns_path(self):
+        from agentteams.frameworks.copilot_vscode import CopilotVSCodeAdapter
+        assert CopilotVSCodeAdapter().vscode_tasks_rel_path() == "../../.vscode/tasks.json"
+
+    def test_claude_returns_path(self):
+        from agentteams.frameworks.claude import ClaudeAdapter
+        assert ClaudeAdapter().vscode_tasks_rel_path() == "../../.vscode/tasks.json"
+
+    def test_goose_returns_path(self):
+        from agentteams.frameworks.goose import GooseAdapter
+        assert GooseAdapter().vscode_tasks_rel_path() == "../../.vscode/tasks.json"
+
+    def test_agents_md_returns_none(self):
+        from agentteams.frameworks.agents_md import AgentsMdAdapter
+        assert AgentsMdAdapter().vscode_tasks_rel_path() is None


### PR DESCRIPTION
Lands two features that were uncommitted and **entangled in shared files**
(`cli/parser.py`, `agentteams.1`, `CHANGELOG.md`), so they merge together. Full suite green (1572).

## Stale detector / remediator
- `agentteams/stale_detector.py` — read-only `--stale-check` across reliability tiers:
  `VCS_CONFLICT_MARKER`, `BROKEN_REF`, git-recency `STALE_VS_CODE`, provenance-gated
  `INTEGRITY`/`SOURCE_DRIFT`; `.agentteams-stale-ignore` suppression; `git ls-files` scan-set.
- `agentteams/stale_remediate.py` — opt-in `--stale-remediate --yes` revision phase:
  sha256-verified safety snapshot, broken-ref relocation repair, bridge re-merge for
  `SOURCE_DRIFT` (routes `INTEGRITY`, never auto-resolves conflicts); `--stale-restore` recovery.
- Wiring (`cli/parser.py`, `cli/app.py`, `cli/commands.py`, `build_team.py`), man-page exit 1/2/3,
  `docs_src/stale-detection-guide.md` (+ mkdocs nav), `tests/test_stale_detector.py`.
- Methods report, plans, and adversarial+conflict audits live under `references/plans/` (gitignored, local).

## VS Code tasks integration (prior in-flight work, completed/green)
- `agentteams/vscode_tasks.py` + tests; emit/render_pipeline/frameworks wiring; `--no-vscode-tasks` opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)