### PR TITLE
feat(ctrl-10): add daily schedule + clarify enforcement point

### DIFF
--- a/.github/workflows/security-maintenance.yml
+++ b/.github/workflows/security-maintenance.yml
@@ -1,6 +1,8 @@
-name: Manual AgentTeams Security Maintenance (Fallback)
+name: AgentTeams Security Maintenance (Daily + Manual Fallback)
 
 on:
+  schedule:
+    - cron: '0 13 * * *'  # 09:00 EDT (UTC-4) / 08:00 EST (UTC-5), daily
   workflow_dispatch:
 
 permissions:

--- a/agentteams/security_refs.py
+++ b/agentteams/security_refs.py
@@ -244,7 +244,7 @@ _CONTROL_EVIDENCE_ROWS: list[dict[str, str]] = [
         "control_id": "CTRL-10",
         "layer": "continuous control drift",
         "test_id": "scripts/run_daily_security_maintenance.sh",
-        "enforcement_point": "daily security maintenance pipeline",
+        "enforcement_point": "daily security maintenance pipeline (.github/workflows/security-maintenance.yml; scheduled 09:00 EDT + workflow_dispatch fallback)",
         "status": "implemented",
     },
 ]


### PR DESCRIPTION
## Summary

- **B1a**: `security-maintenance.yml` — adds `schedule: cron: '0 13 * * *'` (09:00 EDT / 08:00 EST daily). Renames workflow from "Manual AgentTeams Security Maintenance (Fallback)" to "AgentTeams Security Maintenance (Daily + Manual Fallback)". `workflow_dispatch` retained for on-demand runs. `permissions: contents: read` unchanged (script makes no git push-back).
- **B1b**: `security_refs.py` CTRL-10 entry — updates `enforcement_point` to name the GitHub Actions workflow file and scheduling mechanism, disambiguating agentteams-framework scope from downstream consumer repos.

## Context

CTRL-10 was previously documented as "implemented" but the `security-maintenance.yml` trigger was `workflow_dispatch` only — no automated schedule existed. This PR closes that gap by scheduling the workflow daily and making the control evidence row self-documenting about where the control actually runs.

## Test plan

- [x] YAML syntax validated (`yaml.safe_load`)
- [x] `tests/test_security_refs.py` — 16/16 pass
- [x] `tests/test_build_team_security_gates.py` — 60/60 pass (combined with test_scan)
- [x] `tests/test_scan.py` — included in above run
- [x] 76 total security-related tests pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)