### PR TITLE
fix(templates): reframe memory-index consultation for read/search agents (B4a/B4b)

### DIFF
--- a/agentteams/templates/domain/quality-auditor.template.md
+++ b/agentteams/templates/domain/quality-auditor.template.md
@@ -43,12 +43,15 @@ You perform read-only quality audits on deliverables in {PROJECT_NAME}. You **de
 | **Q-LLM** | LLM pattern | Filler phrases, hedging without cause, formulaic paragraph structures |
 | **Q-PRO** | Purposeless prose | Sentences that consume space without advancing argument |
 
-<!-- AGENTTEAMS:BEGIN memory_index_consultation v=2 -->
+<!-- AGENTTEAMS:BEGIN memory_index_consultation v=3 -->
 ## Memory-index consultation *(applies when `references/memory-index.json` is present)*
 
-When a deliverable's defect shape looks recurrent — "have we flagged this LLM pattern / structural defect before?", or "did a prior audit on this deliverable's predecessor adjudicate this passage?" — query the index before opening a new finding. Lexical-first when the query contains a quoted passage, file path, or specific terminology; vector for thematic recurrence questions:
+When a deliverable's defect shape looks recurrent — "have we flagged this LLM pattern / structural defect before?", or "did a prior audit on this deliverable's predecessor adjudicate this passage?" — consult the index before opening a new finding. Lexical-first when the query contains a quoted passage, file path, or specific terminology; vector for thematic recurrence questions.
+
+If your runtime provides an index-access affordance (a search/recall capability over `references/memory-index.json`, e.g. the `recall` skill or the `agentteams --query-index` task), it performs the query — you do **not** execute this yourself (this agent's grant is read/search-only). If no such affordance is available, skip to the three-pass protocol below. The command is illustrative of what the runtime issues:
 
 ```bash
+# illustrative — the runtime's index affordance performs this; the agent does not run it
 agentteams --query-index "<defect description, quoted passage, or deliverable name>" --query-strategy lexical --query-k 5 --description .agentteams/brief.json --project . --output .github/agents --no-scan --yes
 ```
 

--- a/agentteams/templates/domain/technical-validator.template.md
+++ b/agentteams/templates/domain/technical-validator.template.md
@@ -58,12 +58,15 @@ You perform read-only technical accuracy audits on deliverables in {PROJECT_NAME
 | **CH-06** | Agent file excerpts must match the file currently on disk |
 | **CH-07** | Version numbers cited must be the current authoritative version |
 
-<!-- AGENTTEAMS:BEGIN memory_index_consultation v=1 -->
+<!-- AGENTTEAMS:BEGIN memory_index_consultation v=2 -->
 ## Memory-index consultation *(applies when `references/memory-index.json` is present)*
 
-When verifying a code excerpt, API reference, or tool invocation, first check whether a prior validation or known-issue entry exists — many "rename happened in week N" or "command flag deprecated on date D" facts live in work summaries and handoffs that the index covers:
+When verifying a code excerpt, API reference, or tool invocation, first check whether a prior validation or known-issue entry exists — many "rename happened in week N" or "command flag deprecated on date D" facts live in work summaries and handoffs that the index covers.
+
+If your runtime provides an index-access affordance (a search/recall capability over `references/memory-index.json`, e.g. the `recall` skill or the `agentteams --query-index` task), it performs the query — you do **not** execute this yourself (this agent's grant is read/search-only). If no such affordance is available, skip straight to direct file verification. The command is illustrative of what the runtime issues:
 
 ```bash
+# illustrative — the runtime's index affordance performs this; the agent does not run it
 agentteams --query-index "<symbol, file path, or invocation>" --query-strategy lexical --query-k 5 --description .agentteams/brief.json --project . --output .github/agents --no-scan --yes
 ```
 


### PR DESCRIPTION
quality-auditor + technical-validator instructed an unconditional 'agentteams --query-index' under tools:[read,search] (cannot shell out). Reframed to conditional/illustrative, mirroring adversarial.template.md. Fence versions bumped (qa v2->v3, tv v1->v2) so it propagates on --update. 🤖 Generated with Claude Code