### PR TITLE
fix(docs): correct Claude Code hooks schema + verify CLI/slash-command claims

### DIFF
--- a/docs_src/claude-code-cheat-sheet.md
+++ b/docs_src/claude-code-cheat-sheet.md
@@ -133,7 +133,7 @@ Type `/` in the interactive session to see all available commands.
 |---|---|
 | `/plan` | Switch to plan mode (Claude describes changes before making them) |
 | `/loop [interval]` | Re-run the current prompt on a schedule (`/loop 5m`) |
-| `/goal <condition>` | Run autonomously until a condition is true (`/goal "tests pass"`) |
+| `/goal <condition>` | Set an objective to work toward (`/goal "tests pass"`); pair with `/loop` to keep iterating autonomously until the goal validates |
 | `/background` | Detach session to run without blocking your terminal |
 | `/batch <prompt>` | Decompose a large task and run parts in parallel worktrees |
 | `/tasks` | Show background tasks and subagent progress |
@@ -311,40 +311,38 @@ Hooks run shell commands at lifecycle events — enforce coding standards, forma
 | `PreToolUse` | Before any tool call (Bash, Edit, Read, MCP, etc.) |
 | `PostToolUse` | After a tool succeeds |
 | `UserPromptSubmit` | Before Claude processes a user prompt |
-| `SessionStart` | Session begins |
-| `Stop` | Session ends |
-| `FileChanged` | A file is modified |
-| `PreCompact` / `PostCompact` | Context compaction |
+| `SessionStart` | Session begins or resumes |
+| `Stop` | Claude finishes responding (the main agent's turn ends — per-turn, not session end) |
+| `SessionEnd` | The session terminates |
+| `FileChanged` | A watched file changes on disk |
+| `PreCompact` / `PostCompact` | Before / after context compaction |
 
 ### Example hook config
 
 ```json
 {
-  "hooks": [
-    {
-      "event": "PreToolUse",
-      "matcher": {
-        "tool": "Bash",
-        "if": "args.command matches 'rm -rf'"
-      },
-      "handler": {
-        "type": "command",
-        "command": "echo 'rm -rf is blocked' && exit 2"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "cmd=$(jq -r '.tool_input.command'); case \"$cmd\" in *'rm -rf'*) echo 'rm -rf is blocked' >&2; exit 2 ;; esac" }
+        ]
       }
-    },
-    {
-      "event": "PostToolUse",
-      "matcher": { "tool": "Edit" },
-      "handler": {
-        "type": "command",
-        "command": "prettier --write ${CLAUDE_TOOL_RESULT_VALUE.path}"
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "jq -r '.tool_input.file_path' | xargs -r prettier --write 2>/dev/null || true" }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
-View configured hooks in a session with `/hooks`.
+Hooks are keyed by **event name**; `matcher` is a tool-name pattern (string), and each match holds a `hooks` array. The hook reads the event as **JSON on stdin** (`tool_name`, `tool_input`, …) — there is no result-template variable. **Exit 2 blocks** the call (stderr goes to Claude); exit 0 allows it; exit 1 does not block. View configured hooks in a session with `/hooks`.
 
 ---
 

--- a/docs_src/claude-privileges.md
+++ b/docs_src/claude-privileges.md
@@ -219,33 +219,41 @@ Combined with `claudeCode.initialPermissionMode: "plan"` to require human review
 For enforcement logic that patterns can't express (e.g., "allow `npm install` only if `package.json` was modified"), use hooks:
 
 ```json
-// .claude/settings.json
+// .claude/settings.json — hooks are keyed by event name. `matcher` is a
+// tool-name pattern (a string, e.g. "Bash" or "Edit|Write"); each match carries
+// a `hooks` array of command entries. Each hook receives the event as JSON on
+// stdin (fields include `tool_name`, `tool_input`, and — for PostToolUse —
+// `tool_output`); read what you need from that JSON. There is no result-
+// template variable.
 {
-  "hooks": [
-    {
-      "event": "PreToolUse",
-      "matcher": {
-        "tool": "Bash",
-        "if": "args.command matches 'npm install'"
-      },
-      "handler": {
-        "type": "command",
-        "command": "git diff --name-only HEAD | grep -q package.json || (echo 'npm install requires package.json change' && exit 2)"
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command'); case \"$cmd\" in *'npm install'*) git diff --name-only HEAD | grep -q package.json || { echo 'npm install requires a package.json change' >&2; exit 2; } ;; esac"
+          }
+        ]
       }
-    },
-    {
-      "event": "PostToolUse",
-      "matcher": { "tool": "Edit" },
-      "handler": {
-        "type": "command",
-        "command": "prettier --write ${CLAUDE_TOOL_RESULT_VALUE.path} 2>/dev/null || true"
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | xargs -r prettier --write 2>/dev/null || true"
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
-Exit code 2 from a hook handler blocks the tool call and surfaces the message to Claude.
+A hook **exiting with code 2** blocks the tool call and surfaces its stderr to Claude. Exit 0 allows the call (and may emit a JSON decision on stdout for finer control); other non-zero exits are non-blocking errors (notably, **exit 1 does not block**).
 
 ---
 
@@ -255,6 +263,8 @@ To run with no CLAUDE.md, no MCP servers, no hooks, and no memory — useful for
 
 ```bash
 claude --safe-mode
+# Equivalent for non-interactive/CI launches:
+CLAUDE_CODE_SAFE_MODE=1 claude -p "…"
 ```
 
 This does not change any config files. It applies for that session only.

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -299,8 +299,9 @@ def test_classify_tool_importance_explicit_specialist():
     assert classify_tool_importance(tool) == "specialist"
 
 
-def test_classify_tool_importance_explicit_false_overrides_category():
-    """Explicit False still allows auto-classification by category."""
+def test_classify_tool_importance_explicit_false_defers_to_category():
+    """Explicit False is the default no-op (not a non-specialist override): the
+    tool still auto-classifies by category, so a database tool stays specialist."""
     tool = {"name": "PostgreSQL", "category": "database", "needs_specialist_agent": False}
     assert classify_tool_importance(tool) == "specialist"
 


### PR DESCRIPTION
Closes the deferred UNCONFIRMED audit items, verified against the official
Claude Code docs (code.claude.com/docs/en/hooks) via the claude-code-guide agent:

- HOOKS (was wrong): the documented flat-array shape
  `[{event, matcher:{tool,if}, handler:{type,command}}]` with
  `${CLAUDE_TOOL_RESULT_VALUE.path}` does not exist. Rewrote both examples
  (claude-privileges.md, claude-code-cheat-sheet.md) to the real event-keyed
  schema: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command",
  "command":...}]}]}}`. Event data arrives as JSON on stdin
  (`tool_input.command` / `tool_input.file_path`); exit 2 blocks the call (exit 1
  does not). Validated: both blocks parse as event-keyed JSON.
- Event table: `Stop` is per-turn (main agent finished), not session end; added
  the real `SessionEnd` event; clarified FileChanged / PreCompact / PostCompact.
- `--safe-mode` confirmed real; added the `CLAUDE_CODE_SAFE_MODE=1` env alternative.
- `/goal`/`/background`/`/batch` confirmed real; refined `/goal` to note it pairs
  with `/loop` for the autonomous loop.
- G06-A6: code/docstring/AUTHORING-GUIDE are already consistent (needs_specialist_
  agent:false is the default no-op; category decides) — renamed a misleadingly
  named test to match its assertion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
