### PR TITLE
feat(code-hygiene): add CH-27 (long-lived utilities) and CH-28 (minimal edits)

### DIFF
--- a/agentteams/ai_bad_habits.py
+++ b/agentteams/ai_bad_habits.py
@@ -94,6 +94,12 @@ LOCAL_CATALOG: tuple[dict[str, Any], ...] = (
      "habit": "'Make it better' refinement loops accumulate flaws",
      "cross_links": (),
      "fix": "Re-review and re-test after every iteration, not just at the end"},
+    {"id": "BH-10", "category": "hygiene",
+     "habit": "Wholesale file rewrites / reformatting untouched regions when a scoped edit suffices",
+     "cross_links": ("CH-28",),
+     "fix": "Make the smallest change that satisfies the task; never reformat or "
+            "restructure unrelated lines in the same edit (CH-28). Required guards/"
+            "cleanups (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors still apply."},
 )
 
 _CATEGORY_LABELS = {

--- a/agentteams/templates/domain/code-hygiene-rules-reference.template.md
+++ b/agentteams/templates/domain/code-hygiene-rules-reference.template.md
@@ -190,6 +190,105 @@ detail. Where the cross-link is `—`, the catalog entry is itself the rule.
 This rule does not duplicate `@security`'s domain (single-source-of-truth,
 [[CH-05]] / [[CH-14]]).
 
+### CH-26 — Agent Tool Declarations Must Follow the Principle of Least Authority
+
+**Category:** Agent Governance
+**Severity:** High
+
+Each agent's `tools:` YAML field must list only those tools minimally required
+to perform the agent's declared function. Excessive grants are a violation even
+if the agent never exercises the extra capability in practice.
+
+**Guidance by role archetype:**
+
+| Archetype | Typical tools | Notes |
+|---|---|---|
+| Auditors, validators, navigators, critics | `read`, `search` | Read-only by nature; no write or execute grants |
+| Log-writing agents (conflict log, delivery receipt) | `read`, `edit`, `search` | `edit` scoped to log file writes |
+| Execution agents (git, build, format conversion) | `read`, `execute`, `search` | `execute` only when body prose documents a specific shell-invocation step |
+| Writing/production agents | `read`, `edit`, `search` | Standard content-creation set |
+| Delegation agents (orchestrators, experts) | `read`, `edit`, `search`, `execute`, `agent` | Only when all are justified by declared procedures |
+
+**Prohibited patterns:**
+- `execute` on an agent whose Invariant Core and declared procedures contain no shell command invocation
+- `--allow-all-tools` on any subprocess invocation of a Copilot/AI CLI (use `--available-tools=<list>` instead)
+- Tool grants copied from a similar agent without re-evaluating the target agent's actual needs
+- Granting `agent` to an agent that has no `handoffs:` entries and no sub-agent delegation procedures
+
+**Enforcement check:**
+```
+# For each .agent.md file: read its tools: list and its Invariant Core / procedures.
+# Flag any tool that has no corresponding step or body reference justifying its use.
+# Verify no subprocess call uses --allow-all-tools.
+grep -rn "\-\-allow-all-tools" {PRIMARY_OUTPUT_DIR}
+```
+
+### CH-27 — Prefer Long-Lived Utilities Over Ad-Hoc Scripts
+
+**Category:** Modularity / Reuse
+**Severity:** Medium
+
+*Applies to code artifacts.* If a feature being created or managed is **likely to
+be used again**, the logic that creates or manipulates it must live in a
+long-lived, reusable utility (module, library function, CLI subcommand) — not in
+an ad-hoc script, **and not in a script merely *tagged* `RECURRING`/`UTILITY` yet
+re-authored each time.**
+
+**Distinct violation (not redundant with [[CH-02]]/[[CH-03]]):** CH-02 requires
+*tagging and deleting* one-off scripts and CH-03 keeps ad-hoc scripts out of
+source — both are satisfied by an agent that nonetheless keeps writing fresh
+throwaway scripts for recurring work. CH-27 adds the affirmative duty those rules
+do not state: recurring operational work must be **promoted to a durable utility**,
+not repeatedly re-scripted.
+
+**Boundary vs. [[CH-08]] (rule of three) and BH-03:** CH-27 does **not** lower
+CH-08's 3-occurrence extraction threshold and does **not** mandate premature
+abstraction of genuinely single-use helpers (BH-03 in the bad-habits catalog). The
+trigger is foreseeable recurrence judged from the task, not raw repetition count.
+
+**Report-only.** Like every `@code-hygiene` finding, CH-27 is reported; it triggers
+no `@cleanup` deletion of its own.
+
+**Enforcement check (illustrative):**
+```
+# Flag repeated/dated one-off scripts doing equivalent work (fix_*, run_*_v2,
+# dated throwaways), or scripts tagged RECURRING/UTILITY that duplicate logic
+# better housed in a module. Recommend promotion to a long-lived utility.
+```
+
+### CH-28 — Prefer Minimal, Scoped Edits
+
+**Category:** Change Discipline
+**Severity:** Medium (advisory)
+
+*Applies to code artifacts.*
+
+> **Constraints first (closes the "minimal-diff" loophole):** CH-28 NEVER excuses
+> skipping a *required* change. Dead-code removal ([[CH-10]]), correctness guards
+> ([[CH-23]]/[[CH-24]]), and type checks ([[CH-22]]) are mandatory **even when they
+> add lines.** CH-28 does NOT block *sanctioned, scoped* refactors ([[CH-07]]
+> structure carves, [[CH-08]] extractions) or `@agent-refactor`'s mandate — those
+> are intentional work. CH-28 targets only **incidental** scope creep within an
+> otherwise-unrelated change.
+
+Subject to the constraints above: a change should touch only the lines its task
+requires. When an outcome is achievable in a small, localized diff, do not rewrite
+surrounding code, reformat untouched regions, or expand scope. Gratuitous churn
+obscures intent, inflates review cost, and is a common AI-agent failure mode (see
+BH-10 in the bad-habits catalog).
+
+**Advisory & precedented.** CH-28 is reported, never blocking, and triggers no
+deletion. It is not mechanically counted — its enforcement check is illustrative
+**exactly as [[CH-24]] and [[CH-25]] already are.**
+
+**Enforcement check (illustrative):**
+```
+# Judgment-based: report a diff whose churn (rewrites, reformatting of untouched
+# regions, scope expansion) appears disproportionate to the stated task. Never
+# flag a required change (CH-10/CH-22/CH-23/CH-24) or a sanctioned CH-07/CH-08
+# refactor. No automated metric.
+```
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/agentteams/templates/domain/unix-philosophy-mapping-reference.template.md
+++ b/agentteams/templates/domain/unix-philosophy-mapping-reference.template.md
@@ -2,7 +2,7 @@
 # Unix Philosophy — Code Hygiene Mapping ({PROJECT_NAME})
 
 > **Purpose:** Document how code-hygiene rules align with principles from Unix system design and software architecture
-> **Applies to:** CH-01 through CH-24 rule interpretations
+> **Applies to:** CH-01 through CH-28 rule interpretations
 > **Relationship:** This is a *reference for reasoning*, not the authoritative source of rules. See `code-hygiene-rules.reference.md` for the complete enforcement catalog.
 > **Authority Position:** Complements (not supersedes) the authority hierarchy defined in orchestrator.agent.md
 > **Maintenance:** Updated by `@agent-updater` when code-hygiene-rules.reference.md changes AND when interpretations of Unix principles need clarification
@@ -111,7 +111,10 @@ This principle insists on **discoverability and explicitness**. Hidden behaviors
 
 ## Extension Rules (CH-21+) and Design Principles
 
-The repository adds four enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
+The repository adds eight enforcement rules (CH-21 through CH-28). CH-21–CH-26 are
+largely **project-specific operational requirements** complementary to Unix
+philosophy; CH-27 and CH-28 align *directly* with it (Software Tools and the Rule
+of Simplicity, respectively):
 
 | Rule | Tier | Principle Connection |
 |------|------|---------------------|
@@ -119,6 +122,10 @@ The repository adds four enforcement rules. These are **project-specific operati
 | **CH-22** — Type Check Function/Class Inputs | 3 | **Type Safety.** Type checking makes input contracts explicit. Implicit type coercion hides expectations and causes subtle bugs. (Project-specific mandate; complements simplicity principles.) |
 | **CH-23** — Fail Fast on Invalid Inputs | 3 | **Defensive Programming.** Explicit errors reveal problems early. Silent failures hide bugs deep in a system, making them expensive to diagnose. (Project-specific mandate; aligns with transparency but not Unix-specific.) |
 | **CH-24** — Exception Handling Is a Last Resort; Encode Conditions Explicitly | 3 | **Transparency + Defensive Programming.** Encoding cases in dictionaries and failing hard keeps the program's true state visible; broad `try`/`except` hides brokenness and defeats fast iterative debugging. Aligns with "Value Transparency and Clarity" — behavior must be discoverable, not buried under blanket error suppression. (Project-specific mandate; reinforces [[CH-23]].) |
+| **CH-25** — Screen AI-Generated Code Against the Bad-Habits Catalog | 3 | **Process / Quality.** AI-authored code carries recurring quality/correctness habits; screening catches them before integration. (Project-specific mandate; security-class habits are `@security`'s domain.) |
+| **CH-26** — Agent Tool Declarations Follow Least Authority (PoLA) | 2 | **Make Programs That Work Together.** Minimal authority mirrors minimal, well-scoped interfaces — an agent granted only what it needs is easier to reason about and compose. (Governance mandate.) |
+| **CH-27** — Prefer Long-Lived Utilities Over Ad-Hoc Scripts | 1 | **Software Tools / "Make each program do one thing well."** Recurring work belongs in durable, reusable tools, not throwaway scripts. Directly expresses the Unix "build reusable tools" ethos. |
+| **CH-28** — Prefer Minimal, Scoped Edits | 1 | **Rule of Simplicity / Rule of Economy ("Design for Simplicity").** The smallest change that satisfies the task keeps intent and program state legible; gratuitous churn is the complexity Unix philosophy warns against. (Advisory; never overrides required changes or sanctioned refactors.) |
 
 ---
 
@@ -131,7 +138,7 @@ Understanding the alignment between rules and design principles helps developers
 3. **Extend the rule set** — New rules should be grounded in principles or clearly justified as project-specific
 4. **Maintain over time** — Knowing *why* a rule exists makes it easier to keep it in sync as the project evolves
 
-**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-24) that serve operational needs independent of Unix philosophy.
+**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-26) that serve operational needs independent of Unix philosophy, plus CH-27–CH-28 which align with it directly.
 
 ---
 

--- a/agentteams/templates/universal/code-hygiene.template.md
+++ b/agentteams/templates/universal/code-hygiene.template.md
@@ -59,7 +59,10 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New file added to `{PRIMARY_OUTPUT_DIR}` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
 | New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
-| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
+| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` (CH-28 advisory; sanctioned CH-07/CH-08 refactors are exempt) |
+| Recurring work implemented as a re-run script | CH-27 | Report; recommend promotion to a long-lived utility |
+| Diff disproportionate to a small, scoped task | CH-28 | Report only (advisory) |
+| Agent `tools:` grant not justified by the agent's procedures | CH-26 | Report only |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
 | Investigation or debug session ends | CH-16, CH-19 | — |
@@ -108,6 +111,9 @@ Required project extensions for this repository:
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
 | CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 | CH-25 | Screen AI-Generated Code Against the Bad-Habits Catalog | AI-Generated Code | High |
+| CH-26 | Agent Tool Declarations Follow Least Authority (PoLA) | Agent Governance | High |
+| CH-27 | Prefer Long-Lived Utilities Over Ad-Hoc Scripts | Modularity / Reuse | Medium |
+| CH-28 | Prefer Minimal, Scoped Edits | Change Discipline | Medium (advisory) |
 
 **CH-25 — AI bad-habits screening.** When auditing code authored or substantially
 edited by an AI agent, screen it against the AI bad-habits catalog before
@@ -122,6 +128,27 @@ cross-links (`—` means the catalog entry is itself the rule). **Security-class
 habits are out of scope** — insecure-by-default code is owned by `@security`
 (CWE / OWASP LLM & Web + S-rules); route those findings there, do not duplicate
 the security taxonomies here (CH-05/CH-14).
+
+**CH-26 — Least authority for tool grants.** Each agent's `tools:` field must list
+only the tools its declared function requires; excess grants are a violation even
+if never exercised. Full enforcement detail is in the companion reference file.
+
+**CH-27 — Long-lived utilities over ad-hoc scripts.** When a feature is likely to
+be used again, its creation/manipulation must live in a durable, reusable utility,
+not a throwaway script — *and not a script merely tagged `RECURRING`/`UTILITY` yet
+re-authored each time*. This is the affirmative duty that CH-02 (tag→execute→delete)
+and CH-03 (no ad-hoc scripts in source) do not state. It does **not** lower CH-08's
+3-occurrence extraction threshold or mandate abstracting genuinely single-use
+helpers. Report-only; triggers no `@cleanup` deletion.
+
+**CH-28 — Minimal, scoped edits (advisory).** A change should touch only the lines
+its task requires; do not rewrite or reformat untouched regions. **Constraints
+first:** CH-28 never excuses skipping a *required* change — dead-code removal
+(CH-10), correctness guards (CH-23/CH-24), or type checks (CH-22) are mandatory
+even when they add lines — and it never blocks *sanctioned, scoped* refactors
+(CH-07/CH-08) or `@agent-refactor`'s mandate. It targets only incidental scope
+creep. Advisory: reported, never blocking, no deletion; its check is illustrative,
+exactly as CH-24/CH-25 are.
 
 ### Audit Output Format
 
@@ -165,3 +192,6 @@ Overall: 18/20 checks passing
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
 - **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
+- **CH-26 is mandatory in this repository.** Agent `tools:` declarations follow the Principle of Least Authority — only the minimally required tools, even if extra grants are never exercised.
+- **CH-27 is mandatory in this repository.** Recurring, foreseeably-reused work must be promoted to a long-lived utility rather than re-implemented as an ad-hoc (or merely re-run) script. It does not lower CH-08's 3-occurrence threshold (cross-link, not duplication).
+- **CH-28 is advisory in this repository.** Prefer the smallest diff that satisfies the task; never expand scope into unrelated lines. Required changes (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors (CH-07/CH-08, `@agent-refactor`) are always exempt — CH-28 never overrides them.

--- a/examples/data-pipeline/expected/code-hygiene.agent.md
+++ b/examples/data-pipeline/expected/code-hygiene.agent.md
@@ -60,7 +60,10 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New file added to `src/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
 | New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
-| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
+| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` (CH-28 advisory; sanctioned CH-07/CH-08 refactors are exempt) |
+| Recurring work implemented as a re-run script | CH-27 | Report; recommend promotion to a long-lived utility |
+| Diff disproportionate to a small, scoped task | CH-28 | Report only (advisory) |
+| Agent `tools:` grant not justified by the agent's procedures | CH-26 | Report only |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
 | Investigation or debug session ends | CH-16, CH-19 | — |
@@ -109,6 +112,9 @@ Required project extensions for this repository:
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
 | CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 | CH-25 | Screen AI-Generated Code Against the Bad-Habits Catalog | AI-Generated Code | High |
+| CH-26 | Agent Tool Declarations Follow Least Authority (PoLA) | Agent Governance | High |
+| CH-27 | Prefer Long-Lived Utilities Over Ad-Hoc Scripts | Modularity / Reuse | Medium |
+| CH-28 | Prefer Minimal, Scoped Edits | Change Discipline | Medium (advisory) |
 
 **CH-25 — AI bad-habits screening.** When auditing code authored or substantially
 edited by an AI agent, screen it against the AI bad-habits catalog before
@@ -123,6 +129,27 @@ cross-links (`—` means the catalog entry is itself the rule). **Security-class
 habits are out of scope** — insecure-by-default code is owned by `@security`
 (CWE / OWASP LLM & Web + S-rules); route those findings there, do not duplicate
 the security taxonomies here (CH-05/CH-14).
+
+**CH-26 — Least authority for tool grants.** Each agent's `tools:` field must list
+only the tools its declared function requires; excess grants are a violation even
+if never exercised. Full enforcement detail is in the companion reference file.
+
+**CH-27 — Long-lived utilities over ad-hoc scripts.** When a feature is likely to
+be used again, its creation/manipulation must live in a durable, reusable utility,
+not a throwaway script — *and not a script merely tagged `RECURRING`/`UTILITY` yet
+re-authored each time*. This is the affirmative duty that CH-02 (tag→execute→delete)
+and CH-03 (no ad-hoc scripts in source) do not state. It does **not** lower CH-08's
+3-occurrence extraction threshold or mandate abstracting genuinely single-use
+helpers. Report-only; triggers no `@cleanup` deletion.
+
+**CH-28 — Minimal, scoped edits (advisory).** A change should touch only the lines
+its task requires; do not rewrite or reformat untouched regions. **Constraints
+first:** CH-28 never excuses skipping a *required* change — dead-code removal
+(CH-10), correctness guards (CH-23/CH-24), or type checks (CH-22) are mandatory
+even when they add lines — and it never blocks *sanctioned, scoped* refactors
+(CH-07/CH-08) or `@agent-refactor`'s mandate. It targets only incidental scope
+creep. Advisory: reported, never blocking, no deletion; its check is illustrative,
+exactly as CH-24/CH-25 are.
 
 ### Audit Output Format
 
@@ -166,6 +193,9 @@ Overall: 18/20 checks passing
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
 - **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
+- **CH-26 is mandatory in this repository.** Agent `tools:` declarations follow the Principle of Least Authority — only the minimally required tools, even if extra grants are never exercised.
+- **CH-27 is mandatory in this repository.** Recurring, foreseeably-reused work must be promoted to a long-lived utility rather than re-implemented as an ad-hoc (or merely re-run) script. It does not lower CH-08's 3-occurrence threshold (cross-link, not duplication).
+- **CH-28 is advisory in this repository.** Prefer the smallest diff that satisfies the task; never expand scope into unrelated lines. Required changes (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors (CH-07/CH-08, `@agent-refactor`) are always exempt — CH-28 never overrides them.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/data-pipeline/expected/references/ai-bad-habits-watch.reference.md
+++ b/examples/data-pipeline/expected/references/ai-bad-habits-watch.reference.md
@@ -23,6 +23,7 @@ deliberately not catalogued here.
 | BH-03 | Single-use helper functions adding needless indirection | — | Inline single-use helpers; abstract only on the third repetition (rule of three) |
 | BH-04 | Duplicated code blocks instead of reuse | CH-08 | Reuse existing utilities; extract a shared helper at 3 occurrences (DRY) |
 | BH-05 | Tests omitted unless explicitly requested | CH-21 | Tests mandatory (happy path + edge/error cases); enforce a coverage gate |
+| BH-10 | Wholesale file rewrites / reformatting untouched regions when a scoped edit suffices | CH-28 | Make the smallest change that satisfies the task; never reformat or restructure unrelated lines in the same edit (CH-28). Required guards/cleanups (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors still apply. |
 
 ### AI-specific correctness
 

--- a/examples/data-pipeline/expected/references/code-hygiene-rules.reference.md
+++ b/examples/data-pipeline/expected/references/code-hygiene-rules.reference.md
@@ -191,6 +191,105 @@ detail. Where the cross-link is `—`, the catalog entry is itself the rule.
 This rule does not duplicate `@security`'s domain (single-source-of-truth,
 [[CH-05]] / [[CH-14]]).
 
+### CH-26 — Agent Tool Declarations Must Follow the Principle of Least Authority
+
+**Category:** Agent Governance
+**Severity:** High
+
+Each agent's `tools:` YAML field must list only those tools minimally required
+to perform the agent's declared function. Excessive grants are a violation even
+if the agent never exercises the extra capability in practice.
+
+**Guidance by role archetype:**
+
+| Archetype | Typical tools | Notes |
+|---|---|---|
+| Auditors, validators, navigators, critics | `read`, `search` | Read-only by nature; no write or execute grants |
+| Log-writing agents (conflict log, delivery receipt) | `read`, `edit`, `search` | `edit` scoped to log file writes |
+| Execution agents (git, build, format conversion) | `read`, `execute`, `search` | `execute` only when body prose documents a specific shell-invocation step |
+| Writing/production agents | `read`, `edit`, `search` | Standard content-creation set |
+| Delegation agents (orchestrators, experts) | `read`, `edit`, `search`, `execute`, `agent` | Only when all are justified by declared procedures |
+
+**Prohibited patterns:**
+- `execute` on an agent whose Invariant Core and declared procedures contain no shell command invocation
+- `--allow-all-tools` on any subprocess invocation of a Copilot/AI CLI (use `--available-tools=<list>` instead)
+- Tool grants copied from a similar agent without re-evaluating the target agent's actual needs
+- Granting `agent` to an agent that has no `handoffs:` entries and no sub-agent delegation procedures
+
+**Enforcement check:**
+```
+# For each .agent.md file: read its tools: list and its Invariant Core / procedures.
+# Flag any tool that has no corresponding step or body reference justifying its use.
+# Verify no subprocess call uses --allow-all-tools.
+grep -rn "\-\-allow-all-tools" src/
+```
+
+### CH-27 — Prefer Long-Lived Utilities Over Ad-Hoc Scripts
+
+**Category:** Modularity / Reuse
+**Severity:** Medium
+
+*Applies to code artifacts.* If a feature being created or managed is **likely to
+be used again**, the logic that creates or manipulates it must live in a
+long-lived, reusable utility (module, library function, CLI subcommand) — not in
+an ad-hoc script, **and not in a script merely *tagged* `RECURRING`/`UTILITY` yet
+re-authored each time.**
+
+**Distinct violation (not redundant with [[CH-02]]/[[CH-03]]):** CH-02 requires
+*tagging and deleting* one-off scripts and CH-03 keeps ad-hoc scripts out of
+source — both are satisfied by an agent that nonetheless keeps writing fresh
+throwaway scripts for recurring work. CH-27 adds the affirmative duty those rules
+do not state: recurring operational work must be **promoted to a durable utility**,
+not repeatedly re-scripted.
+
+**Boundary vs. [[CH-08]] (rule of three) and BH-03:** CH-27 does **not** lower
+CH-08's 3-occurrence extraction threshold and does **not** mandate premature
+abstraction of genuinely single-use helpers (BH-03 in the bad-habits catalog). The
+trigger is foreseeable recurrence judged from the task, not raw repetition count.
+
+**Report-only.** Like every `@code-hygiene` finding, CH-27 is reported; it triggers
+no `@cleanup` deletion of its own.
+
+**Enforcement check (illustrative):**
+```
+# Flag repeated/dated one-off scripts doing equivalent work (fix_*, run_*_v2,
+# dated throwaways), or scripts tagged RECURRING/UTILITY that duplicate logic
+# better housed in a module. Recommend promotion to a long-lived utility.
+```
+
+### CH-28 — Prefer Minimal, Scoped Edits
+
+**Category:** Change Discipline
+**Severity:** Medium (advisory)
+
+*Applies to code artifacts.*
+
+> **Constraints first (closes the "minimal-diff" loophole):** CH-28 NEVER excuses
+> skipping a *required* change. Dead-code removal ([[CH-10]]), correctness guards
+> ([[CH-23]]/[[CH-24]]), and type checks ([[CH-22]]) are mandatory **even when they
+> add lines.** CH-28 does NOT block *sanctioned, scoped* refactors ([[CH-07]]
+> structure carves, [[CH-08]] extractions) or `@agent-refactor`'s mandate — those
+> are intentional work. CH-28 targets only **incidental** scope creep within an
+> otherwise-unrelated change.
+
+Subject to the constraints above: a change should touch only the lines its task
+requires. When an outcome is achievable in a small, localized diff, do not rewrite
+surrounding code, reformat untouched regions, or expand scope. Gratuitous churn
+obscures intent, inflates review cost, and is a common AI-agent failure mode (see
+BH-10 in the bad-habits catalog).
+
+**Advisory & precedented.** CH-28 is reported, never blocking, and triggers no
+deletion. It is not mechanically counted — its enforcement check is illustrative
+**exactly as [[CH-24]] and [[CH-25]] already are.**
+
+**Enforcement check (illustrative):**
+```
+# Judgment-based: report a diff whose churn (rewrites, reformatting of untouched
+# regions, scope expansion) appears disproportionate to the stated task. Never
+# flag a required change (CH-10/CH-22/CH-23/CH-24) or a sanctioned CH-07/CH-08
+# refactor. No automated metric.
+```
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/examples/data-pipeline/expected/references/unix-philosophy-mapping.reference.md
+++ b/examples/data-pipeline/expected/references/unix-philosophy-mapping.reference.md
@@ -2,7 +2,7 @@
 # Unix Philosophy — Code Hygiene Mapping (SalesDataPipeline)
 
 > **Purpose:** Document how code-hygiene rules align with principles from Unix system design and software architecture
-> **Applies to:** CH-01 through CH-24 rule interpretations
+> **Applies to:** CH-01 through CH-28 rule interpretations
 > **Relationship:** This is a *reference for reasoning*, not the authoritative source of rules. See `code-hygiene-rules.reference.md` for the complete enforcement catalog.
 > **Authority Position:** Complements (not supersedes) the authority hierarchy defined in orchestrator.agent.md
 > **Maintenance:** Updated by `@agent-updater` when code-hygiene-rules.reference.md changes AND when interpretations of Unix principles need clarification
@@ -111,7 +111,10 @@ This principle insists on **discoverability and explicitness**. Hidden behaviors
 
 ## Extension Rules (CH-21+) and Design Principles
 
-The repository adds four enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
+The repository adds eight enforcement rules (CH-21 through CH-28). CH-21–CH-26 are
+largely **project-specific operational requirements** complementary to Unix
+philosophy; CH-27 and CH-28 align *directly* with it (Software Tools and the Rule
+of Simplicity, respectively):
 
 | Rule | Tier | Principle Connection |
 |------|------|---------------------|
@@ -119,6 +122,10 @@ The repository adds four enforcement rules. These are **project-specific operati
 | **CH-22** — Type Check Function/Class Inputs | 3 | **Type Safety.** Type checking makes input contracts explicit. Implicit type coercion hides expectations and causes subtle bugs. (Project-specific mandate; complements simplicity principles.) |
 | **CH-23** — Fail Fast on Invalid Inputs | 3 | **Defensive Programming.** Explicit errors reveal problems early. Silent failures hide bugs deep in a system, making them expensive to diagnose. (Project-specific mandate; aligns with transparency but not Unix-specific.) |
 | **CH-24** — Exception Handling Is a Last Resort; Encode Conditions Explicitly | 3 | **Transparency + Defensive Programming.** Encoding cases in dictionaries and failing hard keeps the program's true state visible; broad `try`/`except` hides brokenness and defeats fast iterative debugging. Aligns with "Value Transparency and Clarity" — behavior must be discoverable, not buried under blanket error suppression. (Project-specific mandate; reinforces [[CH-23]].) |
+| **CH-25** — Screen AI-Generated Code Against the Bad-Habits Catalog | 3 | **Process / Quality.** AI-authored code carries recurring quality/correctness habits; screening catches them before integration. (Project-specific mandate; security-class habits are `@security`'s domain.) |
+| **CH-26** — Agent Tool Declarations Follow Least Authority (PoLA) | 2 | **Make Programs That Work Together.** Minimal authority mirrors minimal, well-scoped interfaces — an agent granted only what it needs is easier to reason about and compose. (Governance mandate.) |
+| **CH-27** — Prefer Long-Lived Utilities Over Ad-Hoc Scripts | 1 | **Software Tools / "Make each program do one thing well."** Recurring work belongs in durable, reusable tools, not throwaway scripts. Directly expresses the Unix "build reusable tools" ethos. |
+| **CH-28** — Prefer Minimal, Scoped Edits | 1 | **Rule of Simplicity / Rule of Economy ("Design for Simplicity").** The smallest change that satisfies the task keeps intent and program state legible; gratuitous churn is the complexity Unix philosophy warns against. (Advisory; never overrides required changes or sanctioned refactors.) |
 
 ---
 
@@ -131,7 +138,7 @@ Understanding the alignment between rules and design principles helps developers
 3. **Extend the rule set** — New rules should be grounded in principles or clearly justified as project-specific
 4. **Maintain over time** — Knowing *why* a rule exists makes it easier to keep it in sync as the project evolves
 
-**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-24) that serve operational needs independent of Unix philosophy.
+**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-26) that serve operational needs independent of Unix philosophy, plus CH-27–CH-28 which align with it directly.
 
 ---
 

--- a/examples/project-repositories/expected/code-hygiene.agent.md
+++ b/examples/project-repositories/expected/code-hygiene.agent.md
@@ -60,7 +60,10 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New file added to `*/outputs/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
 | New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
-| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
+| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` (CH-28 advisory; sanctioned CH-07/CH-08 refactors are exempt) |
+| Recurring work implemented as a re-run script | CH-27 | Report; recommend promotion to a long-lived utility |
+| Diff disproportionate to a small, scoped task | CH-28 | Report only (advisory) |
+| Agent `tools:` grant not justified by the agent's procedures | CH-26 | Report only |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
 | Investigation or debug session ends | CH-16, CH-19 | — |
@@ -109,6 +112,9 @@ Required project extensions for this repository:
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
 | CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 | CH-25 | Screen AI-Generated Code Against the Bad-Habits Catalog | AI-Generated Code | High |
+| CH-26 | Agent Tool Declarations Follow Least Authority (PoLA) | Agent Governance | High |
+| CH-27 | Prefer Long-Lived Utilities Over Ad-Hoc Scripts | Modularity / Reuse | Medium |
+| CH-28 | Prefer Minimal, Scoped Edits | Change Discipline | Medium (advisory) |
 
 **CH-25 — AI bad-habits screening.** When auditing code authored or substantially
 edited by an AI agent, screen it against the AI bad-habits catalog before
@@ -123,6 +129,27 @@ cross-links (`—` means the catalog entry is itself the rule). **Security-class
 habits are out of scope** — insecure-by-default code is owned by `@security`
 (CWE / OWASP LLM & Web + S-rules); route those findings there, do not duplicate
 the security taxonomies here (CH-05/CH-14).
+
+**CH-26 — Least authority for tool grants.** Each agent's `tools:` field must list
+only the tools its declared function requires; excess grants are a violation even
+if never exercised. Full enforcement detail is in the companion reference file.
+
+**CH-27 — Long-lived utilities over ad-hoc scripts.** When a feature is likely to
+be used again, its creation/manipulation must live in a durable, reusable utility,
+not a throwaway script — *and not a script merely tagged `RECURRING`/`UTILITY` yet
+re-authored each time*. This is the affirmative duty that CH-02 (tag→execute→delete)
+and CH-03 (no ad-hoc scripts in source) do not state. It does **not** lower CH-08's
+3-occurrence extraction threshold or mandate abstracting genuinely single-use
+helpers. Report-only; triggers no `@cleanup` deletion.
+
+**CH-28 — Minimal, scoped edits (advisory).** A change should touch only the lines
+its task requires; do not rewrite or reformat untouched regions. **Constraints
+first:** CH-28 never excuses skipping a *required* change — dead-code removal
+(CH-10), correctness guards (CH-23/CH-24), or type checks (CH-22) are mandatory
+even when they add lines — and it never blocks *sanctioned, scoped* refactors
+(CH-07/CH-08) or `@agent-refactor`'s mandate. It targets only incidental scope
+creep. Advisory: reported, never blocking, no deletion; its check is illustrative,
+exactly as CH-24/CH-25 are.
 
 ### Audit Output Format
 
@@ -166,6 +193,9 @@ Overall: 18/20 checks passing
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
 - **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
+- **CH-26 is mandatory in this repository.** Agent `tools:` declarations follow the Principle of Least Authority — only the minimally required tools, even if extra grants are never exercised.
+- **CH-27 is mandatory in this repository.** Recurring, foreseeably-reused work must be promoted to a long-lived utility rather than re-implemented as an ad-hoc (or merely re-run) script. It does not lower CH-08's 3-occurrence threshold (cross-link, not duplication).
+- **CH-28 is advisory in this repository.** Prefer the smallest diff that satisfies the task; never expand scope into unrelated lines. Required changes (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors (CH-07/CH-08, `@agent-refactor`) are always exempt — CH-28 never overrides them.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/project-repositories/expected/references/ai-bad-habits-watch.reference.md
+++ b/examples/project-repositories/expected/references/ai-bad-habits-watch.reference.md
@@ -23,6 +23,7 @@ deliberately not catalogued here.
 | BH-03 | Single-use helper functions adding needless indirection | — | Inline single-use helpers; abstract only on the third repetition (rule of three) |
 | BH-04 | Duplicated code blocks instead of reuse | CH-08 | Reuse existing utilities; extract a shared helper at 3 occurrences (DRY) |
 | BH-05 | Tests omitted unless explicitly requested | CH-21 | Tests mandatory (happy path + edge/error cases); enforce a coverage gate |
+| BH-10 | Wholesale file rewrites / reformatting untouched regions when a scoped edit suffices | CH-28 | Make the smallest change that satisfies the task; never reformat or restructure unrelated lines in the same edit (CH-28). Required guards/cleanups (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors still apply. |
 
 ### AI-specific correctness
 

--- a/examples/project-repositories/expected/references/code-hygiene-rules.reference.md
+++ b/examples/project-repositories/expected/references/code-hygiene-rules.reference.md
@@ -191,6 +191,105 @@ detail. Where the cross-link is `—`, the catalog entry is itself the rule.
 This rule does not duplicate `@security`'s domain (single-source-of-truth,
 [[CH-05]] / [[CH-14]]).
 
+### CH-26 — Agent Tool Declarations Must Follow the Principle of Least Authority
+
+**Category:** Agent Governance
+**Severity:** High
+
+Each agent's `tools:` YAML field must list only those tools minimally required
+to perform the agent's declared function. Excessive grants are a violation even
+if the agent never exercises the extra capability in practice.
+
+**Guidance by role archetype:**
+
+| Archetype | Typical tools | Notes |
+|---|---|---|
+| Auditors, validators, navigators, critics | `read`, `search` | Read-only by nature; no write or execute grants |
+| Log-writing agents (conflict log, delivery receipt) | `read`, `edit`, `search` | `edit` scoped to log file writes |
+| Execution agents (git, build, format conversion) | `read`, `execute`, `search` | `execute` only when body prose documents a specific shell-invocation step |
+| Writing/production agents | `read`, `edit`, `search` | Standard content-creation set |
+| Delegation agents (orchestrators, experts) | `read`, `edit`, `search`, `execute`, `agent` | Only when all are justified by declared procedures |
+
+**Prohibited patterns:**
+- `execute` on an agent whose Invariant Core and declared procedures contain no shell command invocation
+- `--allow-all-tools` on any subprocess invocation of a Copilot/AI CLI (use `--available-tools=<list>` instead)
+- Tool grants copied from a similar agent without re-evaluating the target agent's actual needs
+- Granting `agent` to an agent that has no `handoffs:` entries and no sub-agent delegation procedures
+
+**Enforcement check:**
+```
+# For each .agent.md file: read its tools: list and its Invariant Core / procedures.
+# Flag any tool that has no corresponding step or body reference justifying its use.
+# Verify no subprocess call uses --allow-all-tools.
+grep -rn "\-\-allow-all-tools" */outputs/
+```
+
+### CH-27 — Prefer Long-Lived Utilities Over Ad-Hoc Scripts
+
+**Category:** Modularity / Reuse
+**Severity:** Medium
+
+*Applies to code artifacts.* If a feature being created or managed is **likely to
+be used again**, the logic that creates or manipulates it must live in a
+long-lived, reusable utility (module, library function, CLI subcommand) — not in
+an ad-hoc script, **and not in a script merely *tagged* `RECURRING`/`UTILITY` yet
+re-authored each time.**
+
+**Distinct violation (not redundant with [[CH-02]]/[[CH-03]]):** CH-02 requires
+*tagging and deleting* one-off scripts and CH-03 keeps ad-hoc scripts out of
+source — both are satisfied by an agent that nonetheless keeps writing fresh
+throwaway scripts for recurring work. CH-27 adds the affirmative duty those rules
+do not state: recurring operational work must be **promoted to a durable utility**,
+not repeatedly re-scripted.
+
+**Boundary vs. [[CH-08]] (rule of three) and BH-03:** CH-27 does **not** lower
+CH-08's 3-occurrence extraction threshold and does **not** mandate premature
+abstraction of genuinely single-use helpers (BH-03 in the bad-habits catalog). The
+trigger is foreseeable recurrence judged from the task, not raw repetition count.
+
+**Report-only.** Like every `@code-hygiene` finding, CH-27 is reported; it triggers
+no `@cleanup` deletion of its own.
+
+**Enforcement check (illustrative):**
+```
+# Flag repeated/dated one-off scripts doing equivalent work (fix_*, run_*_v2,
+# dated throwaways), or scripts tagged RECURRING/UTILITY that duplicate logic
+# better housed in a module. Recommend promotion to a long-lived utility.
+```
+
+### CH-28 — Prefer Minimal, Scoped Edits
+
+**Category:** Change Discipline
+**Severity:** Medium (advisory)
+
+*Applies to code artifacts.*
+
+> **Constraints first (closes the "minimal-diff" loophole):** CH-28 NEVER excuses
+> skipping a *required* change. Dead-code removal ([[CH-10]]), correctness guards
+> ([[CH-23]]/[[CH-24]]), and type checks ([[CH-22]]) are mandatory **even when they
+> add lines.** CH-28 does NOT block *sanctioned, scoped* refactors ([[CH-07]]
+> structure carves, [[CH-08]] extractions) or `@agent-refactor`'s mandate — those
+> are intentional work. CH-28 targets only **incidental** scope creep within an
+> otherwise-unrelated change.
+
+Subject to the constraints above: a change should touch only the lines its task
+requires. When an outcome is achievable in a small, localized diff, do not rewrite
+surrounding code, reformat untouched regions, or expand scope. Gratuitous churn
+obscures intent, inflates review cost, and is a common AI-agent failure mode (see
+BH-10 in the bad-habits catalog).
+
+**Advisory & precedented.** CH-28 is reported, never blocking, and triggers no
+deletion. It is not mechanically counted — its enforcement check is illustrative
+**exactly as [[CH-24]] and [[CH-25]] already are.**
+
+**Enforcement check (illustrative):**
+```
+# Judgment-based: report a diff whose churn (rewrites, reformatting of untouched
+# regions, scope expansion) appears disproportionate to the stated task. Never
+# flag a required change (CH-10/CH-22/CH-23/CH-24) or a sanctioned CH-07/CH-08
+# refactor. No automated metric.
+```
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/examples/project-repositories/expected/references/unix-philosophy-mapping.reference.md
+++ b/examples/project-repositories/expected/references/unix-philosophy-mapping.reference.md
@@ -2,7 +2,7 @@
 # Unix Philosophy — Code Hygiene Mapping (ProjectRepositories)
 
 > **Purpose:** Document how code-hygiene rules align with principles from Unix system design and software architecture
-> **Applies to:** CH-01 through CH-24 rule interpretations
+> **Applies to:** CH-01 through CH-28 rule interpretations
 > **Relationship:** This is a *reference for reasoning*, not the authoritative source of rules. See `code-hygiene-rules.reference.md` for the complete enforcement catalog.
 > **Authority Position:** Complements (not supersedes) the authority hierarchy defined in orchestrator.agent.md
 > **Maintenance:** Updated by `@agent-updater` when code-hygiene-rules.reference.md changes AND when interpretations of Unix principles need clarification
@@ -111,7 +111,10 @@ This principle insists on **discoverability and explicitness**. Hidden behaviors
 
 ## Extension Rules (CH-21+) and Design Principles
 
-The repository adds four enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
+The repository adds eight enforcement rules (CH-21 through CH-28). CH-21–CH-26 are
+largely **project-specific operational requirements** complementary to Unix
+philosophy; CH-27 and CH-28 align *directly* with it (Software Tools and the Rule
+of Simplicity, respectively):
 
 | Rule | Tier | Principle Connection |
 |------|------|---------------------|
@@ -119,6 +122,10 @@ The repository adds four enforcement rules. These are **project-specific operati
 | **CH-22** — Type Check Function/Class Inputs | 3 | **Type Safety.** Type checking makes input contracts explicit. Implicit type coercion hides expectations and causes subtle bugs. (Project-specific mandate; complements simplicity principles.) |
 | **CH-23** — Fail Fast on Invalid Inputs | 3 | **Defensive Programming.** Explicit errors reveal problems early. Silent failures hide bugs deep in a system, making them expensive to diagnose. (Project-specific mandate; aligns with transparency but not Unix-specific.) |
 | **CH-24** — Exception Handling Is a Last Resort; Encode Conditions Explicitly | 3 | **Transparency + Defensive Programming.** Encoding cases in dictionaries and failing hard keeps the program's true state visible; broad `try`/`except` hides brokenness and defeats fast iterative debugging. Aligns with "Value Transparency and Clarity" — behavior must be discoverable, not buried under blanket error suppression. (Project-specific mandate; reinforces [[CH-23]].) |
+| **CH-25** — Screen AI-Generated Code Against the Bad-Habits Catalog | 3 | **Process / Quality.** AI-authored code carries recurring quality/correctness habits; screening catches them before integration. (Project-specific mandate; security-class habits are `@security`'s domain.) |
+| **CH-26** — Agent Tool Declarations Follow Least Authority (PoLA) | 2 | **Make Programs That Work Together.** Minimal authority mirrors minimal, well-scoped interfaces — an agent granted only what it needs is easier to reason about and compose. (Governance mandate.) |
+| **CH-27** — Prefer Long-Lived Utilities Over Ad-Hoc Scripts | 1 | **Software Tools / "Make each program do one thing well."** Recurring work belongs in durable, reusable tools, not throwaway scripts. Directly expresses the Unix "build reusable tools" ethos. |
+| **CH-28** — Prefer Minimal, Scoped Edits | 1 | **Rule of Simplicity / Rule of Economy ("Design for Simplicity").** The smallest change that satisfies the task keeps intent and program state legible; gratuitous churn is the complexity Unix philosophy warns against. (Advisory; never overrides required changes or sanctioned refactors.) |
 
 ---
 
@@ -131,7 +138,7 @@ Understanding the alignment between rules and design principles helps developers
 3. **Extend the rule set** — New rules should be grounded in principles or clearly justified as project-specific
 4. **Maintain over time** — Knowing *why* a rule exists makes it easier to keep it in sync as the project evolves
 
-**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-24) that serve operational needs independent of Unix philosophy.
+**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-26) that serve operational needs independent of Unix philosophy, plus CH-27–CH-28 which align with it directly.
 
 ---
 

--- a/examples/research-project/expected/code-hygiene.agent.md
+++ b/examples/research-project/expected/code-hygiene.agent.md
@@ -60,7 +60,10 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New file added to `html/chapters/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
 | New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
-| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
+| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` (CH-28 advisory; sanctioned CH-07/CH-08 refactors are exempt) |
+| Recurring work implemented as a re-run script | CH-27 | Report; recommend promotion to a long-lived utility |
+| Diff disproportionate to a small, scoped task | CH-28 | Report only (advisory) |
+| Agent `tools:` grant not justified by the agent's procedures | CH-26 | Report only |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
 | Investigation or debug session ends | CH-16, CH-19 | — |
@@ -109,6 +112,9 @@ Required project extensions for this repository:
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
 | CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 | CH-25 | Screen AI-Generated Code Against the Bad-Habits Catalog | AI-Generated Code | High |
+| CH-26 | Agent Tool Declarations Follow Least Authority (PoLA) | Agent Governance | High |
+| CH-27 | Prefer Long-Lived Utilities Over Ad-Hoc Scripts | Modularity / Reuse | Medium |
+| CH-28 | Prefer Minimal, Scoped Edits | Change Discipline | Medium (advisory) |
 
 **CH-25 — AI bad-habits screening.** When auditing code authored or substantially
 edited by an AI agent, screen it against the AI bad-habits catalog before
@@ -123,6 +129,27 @@ cross-links (`—` means the catalog entry is itself the rule). **Security-class
 habits are out of scope** — insecure-by-default code is owned by `@security`
 (CWE / OWASP LLM & Web + S-rules); route those findings there, do not duplicate
 the security taxonomies here (CH-05/CH-14).
+
+**CH-26 — Least authority for tool grants.** Each agent's `tools:` field must list
+only the tools its declared function requires; excess grants are a violation even
+if never exercised. Full enforcement detail is in the companion reference file.
+
+**CH-27 — Long-lived utilities over ad-hoc scripts.** When a feature is likely to
+be used again, its creation/manipulation must live in a durable, reusable utility,
+not a throwaway script — *and not a script merely tagged `RECURRING`/`UTILITY` yet
+re-authored each time*. This is the affirmative duty that CH-02 (tag→execute→delete)
+and CH-03 (no ad-hoc scripts in source) do not state. It does **not** lower CH-08's
+3-occurrence extraction threshold or mandate abstracting genuinely single-use
+helpers. Report-only; triggers no `@cleanup` deletion.
+
+**CH-28 — Minimal, scoped edits (advisory).** A change should touch only the lines
+its task requires; do not rewrite or reformat untouched regions. **Constraints
+first:** CH-28 never excuses skipping a *required* change — dead-code removal
+(CH-10), correctness guards (CH-23/CH-24), or type checks (CH-22) are mandatory
+even when they add lines — and it never blocks *sanctioned, scoped* refactors
+(CH-07/CH-08) or `@agent-refactor`'s mandate. It targets only incidental scope
+creep. Advisory: reported, never blocking, no deletion; its check is illustrative,
+exactly as CH-24/CH-25 are.
 
 ### Audit Output Format
 
@@ -166,6 +193,9 @@ Overall: 18/20 checks passing
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
 - **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
+- **CH-26 is mandatory in this repository.** Agent `tools:` declarations follow the Principle of Least Authority — only the minimally required tools, even if extra grants are never exercised.
+- **CH-27 is mandatory in this repository.** Recurring, foreseeably-reused work must be promoted to a long-lived utility rather than re-implemented as an ad-hoc (or merely re-run) script. It does not lower CH-08's 3-occurrence threshold (cross-link, not duplication).
+- **CH-28 is advisory in this repository.** Prefer the smallest diff that satisfies the task; never expand scope into unrelated lines. Required changes (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors (CH-07/CH-08, `@agent-refactor`) are always exempt — CH-28 never overrides them.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/research-project/expected/references/ai-bad-habits-watch.reference.md
+++ b/examples/research-project/expected/references/ai-bad-habits-watch.reference.md
@@ -23,6 +23,7 @@ deliberately not catalogued here.
 | BH-03 | Single-use helper functions adding needless indirection | — | Inline single-use helpers; abstract only on the third repetition (rule of three) |
 | BH-04 | Duplicated code blocks instead of reuse | CH-08 | Reuse existing utilities; extract a shared helper at 3 occurrences (DRY) |
 | BH-05 | Tests omitted unless explicitly requested | CH-21 | Tests mandatory (happy path + edge/error cases); enforce a coverage gate |
+| BH-10 | Wholesale file rewrites / reformatting untouched regions when a scoped edit suffices | CH-28 | Make the smallest change that satisfies the task; never reformat or restructure unrelated lines in the same edit (CH-28). Required guards/cleanups (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors still apply. |
 
 ### AI-specific correctness
 

--- a/examples/research-project/expected/references/code-hygiene-rules.reference.md
+++ b/examples/research-project/expected/references/code-hygiene-rules.reference.md
@@ -191,6 +191,105 @@ detail. Where the cross-link is `—`, the catalog entry is itself the rule.
 This rule does not duplicate `@security`'s domain (single-source-of-truth,
 [[CH-05]] / [[CH-14]]).
 
+### CH-26 — Agent Tool Declarations Must Follow the Principle of Least Authority
+
+**Category:** Agent Governance
+**Severity:** High
+
+Each agent's `tools:` YAML field must list only those tools minimally required
+to perform the agent's declared function. Excessive grants are a violation even
+if the agent never exercises the extra capability in practice.
+
+**Guidance by role archetype:**
+
+| Archetype | Typical tools | Notes |
+|---|---|---|
+| Auditors, validators, navigators, critics | `read`, `search` | Read-only by nature; no write or execute grants |
+| Log-writing agents (conflict log, delivery receipt) | `read`, `edit`, `search` | `edit` scoped to log file writes |
+| Execution agents (git, build, format conversion) | `read`, `execute`, `search` | `execute` only when body prose documents a specific shell-invocation step |
+| Writing/production agents | `read`, `edit`, `search` | Standard content-creation set |
+| Delegation agents (orchestrators, experts) | `read`, `edit`, `search`, `execute`, `agent` | Only when all are justified by declared procedures |
+
+**Prohibited patterns:**
+- `execute` on an agent whose Invariant Core and declared procedures contain no shell command invocation
+- `--allow-all-tools` on any subprocess invocation of a Copilot/AI CLI (use `--available-tools=<list>` instead)
+- Tool grants copied from a similar agent without re-evaluating the target agent's actual needs
+- Granting `agent` to an agent that has no `handoffs:` entries and no sub-agent delegation procedures
+
+**Enforcement check:**
+```
+# For each .agent.md file: read its tools: list and its Invariant Core / procedures.
+# Flag any tool that has no corresponding step or body reference justifying its use.
+# Verify no subprocess call uses --allow-all-tools.
+grep -rn "\-\-allow-all-tools" html/chapters/
+```
+
+### CH-27 — Prefer Long-Lived Utilities Over Ad-Hoc Scripts
+
+**Category:** Modularity / Reuse
+**Severity:** Medium
+
+*Applies to code artifacts.* If a feature being created or managed is **likely to
+be used again**, the logic that creates or manipulates it must live in a
+long-lived, reusable utility (module, library function, CLI subcommand) — not in
+an ad-hoc script, **and not in a script merely *tagged* `RECURRING`/`UTILITY` yet
+re-authored each time.**
+
+**Distinct violation (not redundant with [[CH-02]]/[[CH-03]]):** CH-02 requires
+*tagging and deleting* one-off scripts and CH-03 keeps ad-hoc scripts out of
+source — both are satisfied by an agent that nonetheless keeps writing fresh
+throwaway scripts for recurring work. CH-27 adds the affirmative duty those rules
+do not state: recurring operational work must be **promoted to a durable utility**,
+not repeatedly re-scripted.
+
+**Boundary vs. [[CH-08]] (rule of three) and BH-03:** CH-27 does **not** lower
+CH-08's 3-occurrence extraction threshold and does **not** mandate premature
+abstraction of genuinely single-use helpers (BH-03 in the bad-habits catalog). The
+trigger is foreseeable recurrence judged from the task, not raw repetition count.
+
+**Report-only.** Like every `@code-hygiene` finding, CH-27 is reported; it triggers
+no `@cleanup` deletion of its own.
+
+**Enforcement check (illustrative):**
+```
+# Flag repeated/dated one-off scripts doing equivalent work (fix_*, run_*_v2,
+# dated throwaways), or scripts tagged RECURRING/UTILITY that duplicate logic
+# better housed in a module. Recommend promotion to a long-lived utility.
+```
+
+### CH-28 — Prefer Minimal, Scoped Edits
+
+**Category:** Change Discipline
+**Severity:** Medium (advisory)
+
+*Applies to code artifacts.*
+
+> **Constraints first (closes the "minimal-diff" loophole):** CH-28 NEVER excuses
+> skipping a *required* change. Dead-code removal ([[CH-10]]), correctness guards
+> ([[CH-23]]/[[CH-24]]), and type checks ([[CH-22]]) are mandatory **even when they
+> add lines.** CH-28 does NOT block *sanctioned, scoped* refactors ([[CH-07]]
+> structure carves, [[CH-08]] extractions) or `@agent-refactor`'s mandate — those
+> are intentional work. CH-28 targets only **incidental** scope creep within an
+> otherwise-unrelated change.
+
+Subject to the constraints above: a change should touch only the lines its task
+requires. When an outcome is achievable in a small, localized diff, do not rewrite
+surrounding code, reformat untouched regions, or expand scope. Gratuitous churn
+obscures intent, inflates review cost, and is a common AI-agent failure mode (see
+BH-10 in the bad-habits catalog).
+
+**Advisory & precedented.** CH-28 is reported, never blocking, and triggers no
+deletion. It is not mechanically counted — its enforcement check is illustrative
+**exactly as [[CH-24]] and [[CH-25]] already are.**
+
+**Enforcement check (illustrative):**
+```
+# Judgment-based: report a diff whose churn (rewrites, reformatting of untouched
+# regions, scope expansion) appears disproportionate to the stated task. Never
+# flag a required change (CH-10/CH-22/CH-23/CH-24) or a sanctioned CH-07/CH-08
+# refactor. No automated metric.
+```
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/examples/research-project/expected/references/unix-philosophy-mapping.reference.md
+++ b/examples/research-project/expected/references/unix-philosophy-mapping.reference.md
@@ -2,7 +2,7 @@
 # Unix Philosophy — Code Hygiene Mapping (ResearchPaperProject)
 
 > **Purpose:** Document how code-hygiene rules align with principles from Unix system design and software architecture
-> **Applies to:** CH-01 through CH-24 rule interpretations
+> **Applies to:** CH-01 through CH-28 rule interpretations
 > **Relationship:** This is a *reference for reasoning*, not the authoritative source of rules. See `code-hygiene-rules.reference.md` for the complete enforcement catalog.
 > **Authority Position:** Complements (not supersedes) the authority hierarchy defined in orchestrator.agent.md
 > **Maintenance:** Updated by `@agent-updater` when code-hygiene-rules.reference.md changes AND when interpretations of Unix principles need clarification
@@ -111,7 +111,10 @@ This principle insists on **discoverability and explicitness**. Hidden behaviors
 
 ## Extension Rules (CH-21+) and Design Principles
 
-The repository adds four enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
+The repository adds eight enforcement rules (CH-21 through CH-28). CH-21–CH-26 are
+largely **project-specific operational requirements** complementary to Unix
+philosophy; CH-27 and CH-28 align *directly* with it (Software Tools and the Rule
+of Simplicity, respectively):
 
 | Rule | Tier | Principle Connection |
 |------|------|---------------------|
@@ -119,6 +122,10 @@ The repository adds four enforcement rules. These are **project-specific operati
 | **CH-22** — Type Check Function/Class Inputs | 3 | **Type Safety.** Type checking makes input contracts explicit. Implicit type coercion hides expectations and causes subtle bugs. (Project-specific mandate; complements simplicity principles.) |
 | **CH-23** — Fail Fast on Invalid Inputs | 3 | **Defensive Programming.** Explicit errors reveal problems early. Silent failures hide bugs deep in a system, making them expensive to diagnose. (Project-specific mandate; aligns with transparency but not Unix-specific.) |
 | **CH-24** — Exception Handling Is a Last Resort; Encode Conditions Explicitly | 3 | **Transparency + Defensive Programming.** Encoding cases in dictionaries and failing hard keeps the program's true state visible; broad `try`/`except` hides brokenness and defeats fast iterative debugging. Aligns with "Value Transparency and Clarity" — behavior must be discoverable, not buried under blanket error suppression. (Project-specific mandate; reinforces [[CH-23]].) |
+| **CH-25** — Screen AI-Generated Code Against the Bad-Habits Catalog | 3 | **Process / Quality.** AI-authored code carries recurring quality/correctness habits; screening catches them before integration. (Project-specific mandate; security-class habits are `@security`'s domain.) |
+| **CH-26** — Agent Tool Declarations Follow Least Authority (PoLA) | 2 | **Make Programs That Work Together.** Minimal authority mirrors minimal, well-scoped interfaces — an agent granted only what it needs is easier to reason about and compose. (Governance mandate.) |
+| **CH-27** — Prefer Long-Lived Utilities Over Ad-Hoc Scripts | 1 | **Software Tools / "Make each program do one thing well."** Recurring work belongs in durable, reusable tools, not throwaway scripts. Directly expresses the Unix "build reusable tools" ethos. |
+| **CH-28** — Prefer Minimal, Scoped Edits | 1 | **Rule of Simplicity / Rule of Economy ("Design for Simplicity").** The smallest change that satisfies the task keeps intent and program state legible; gratuitous churn is the complexity Unix philosophy warns against. (Advisory; never overrides required changes or sanctioned refactors.) |
 
 ---
 
@@ -131,7 +138,7 @@ Understanding the alignment between rules and design principles helps developers
 3. **Extend the rule set** — New rules should be grounded in principles or clearly justified as project-specific
 4. **Maintain over time** — Knowing *why* a rule exists makes it easier to keep it in sync as the project evolves
 
-**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-24) that serve operational needs independent of Unix philosophy.
+**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-26) that serve operational needs independent of Unix philosophy, plus CH-27–CH-28 which align with it directly.
 
 ---
 

--- a/examples/software-project/expected/code-hygiene.agent.md
+++ b/examples/software-project/expected/code-hygiene.agent.md
@@ -60,7 +60,10 @@ When interpreting rules or proposing extensions, consult this reference to under
 | New file added to `src/` | CH-03 (no ad-hoc in source) | — |
 | Shared utility modified | CH-08, CH-13 | — |
 | New `try`/`except`/`finally` block added | CH-23, CH-24 | Report only; correction by `@primary-producer` |
-| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` |
+| Refactoring task requested | CH-07, CH-08 | Delegate to `@agent-refactor` (CH-28 advisory; sanctioned CH-07/CH-08 refactors are exempt) |
+| Recurring work implemented as a re-run script | CH-27 | Report; recommend promotion to a long-lived utility |
+| Diff disproportionate to a small, scoped task | CH-28 | Report only (advisory) |
+| Agent `tools:` grant not justified by the agent's procedures | CH-26 | Report only |
 | Agent files contain inline data >10 lines | CH-08, CH-14 | Delegate to `@agent-refactor` |
 | Agent doc contradictions found | CH-20 | Delegate to `@conflict-auditor`; alert `@agent-refactor` |
 | Investigation or debug session ends | CH-16, CH-19 | — |
@@ -109,6 +112,9 @@ Required project extensions for this repository:
 | CH-23 | Fail Fast on Invalid Inputs | Defensive Programming | **Critical** |
 | CH-24 | Exception Handling Is a Last Resort; Encode Conditions Explicitly | Defensive Programming | **Critical** |
 | CH-25 | Screen AI-Generated Code Against the Bad-Habits Catalog | AI-Generated Code | High |
+| CH-26 | Agent Tool Declarations Follow Least Authority (PoLA) | Agent Governance | High |
+| CH-27 | Prefer Long-Lived Utilities Over Ad-Hoc Scripts | Modularity / Reuse | Medium |
+| CH-28 | Prefer Minimal, Scoped Edits | Change Discipline | Medium (advisory) |
 
 **CH-25 — AI bad-habits screening.** When auditing code authored or substantially
 edited by an AI agent, screen it against the AI bad-habits catalog before
@@ -123,6 +129,27 @@ cross-links (`—` means the catalog entry is itself the rule). **Security-class
 habits are out of scope** — insecure-by-default code is owned by `@security`
 (CWE / OWASP LLM & Web + S-rules); route those findings there, do not duplicate
 the security taxonomies here (CH-05/CH-14).
+
+**CH-26 — Least authority for tool grants.** Each agent's `tools:` field must list
+only the tools its declared function requires; excess grants are a violation even
+if never exercised. Full enforcement detail is in the companion reference file.
+
+**CH-27 — Long-lived utilities over ad-hoc scripts.** When a feature is likely to
+be used again, its creation/manipulation must live in a durable, reusable utility,
+not a throwaway script — *and not a script merely tagged `RECURRING`/`UTILITY` yet
+re-authored each time*. This is the affirmative duty that CH-02 (tag→execute→delete)
+and CH-03 (no ad-hoc scripts in source) do not state. It does **not** lower CH-08's
+3-occurrence extraction threshold or mandate abstracting genuinely single-use
+helpers. Report-only; triggers no `@cleanup` deletion.
+
+**CH-28 — Minimal, scoped edits (advisory).** A change should touch only the lines
+its task requires; do not rewrite or reformat untouched regions. **Constraints
+first:** CH-28 never excuses skipping a *required* change — dead-code removal
+(CH-10), correctness guards (CH-23/CH-24), or type checks (CH-22) are mandatory
+even when they add lines — and it never blocks *sanctioned, scoped* refactors
+(CH-07/CH-08) or `@agent-refactor`'s mandate. It targets only incidental scope
+creep. Advisory: reported, never blocking, no deletion; its check is illustrative,
+exactly as CH-24/CH-25 are.
 
 ### Audit Output Format
 
@@ -166,6 +193,9 @@ Overall: 18/20 checks passing
 - **CH-22 is mandatory in this repository.** Function/class inputs must be type-checked so only meaningful input types are accepted.
 - **CH-23 is mandatory in this repository.** Invalid inputs must raise explicit errors and must never fail silently.
 - **CH-24 is mandatory in this repository.** `try`/`except`/`finally` is a last resort, reserved for genuinely unavoidable external failures (I/O, network, third-party calls). Prefer encoding expected conditions in dictionaries / lookup tables / explicit guards and failing hard on the unexpected, so a broken program surfaces immediately instead of being masked by broad exception handling.
+- **CH-26 is mandatory in this repository.** Agent `tools:` declarations follow the Principle of Least Authority — only the minimally required tools, even if extra grants are never exercised.
+- **CH-27 is mandatory in this repository.** Recurring, foreseeably-reused work must be promoted to a long-lived utility rather than re-implemented as an ad-hoc (or merely re-run) script. It does not lower CH-08's 3-occurrence threshold (cross-link, not duplication).
+- **CH-28 is advisory in this repository.** Prefer the smallest diff that satisfies the task; never expand scope into unrelated lines. Required changes (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors (CH-07/CH-08, `@agent-refactor`) are always exempt — CH-28 never overrides them.
 <!-- AGENTTEAMS:END content -->
 
 ## Project-Specific Notes

--- a/examples/software-project/expected/references/ai-bad-habits-watch.reference.md
+++ b/examples/software-project/expected/references/ai-bad-habits-watch.reference.md
@@ -23,6 +23,7 @@ deliberately not catalogued here.
 | BH-03 | Single-use helper functions adding needless indirection | — | Inline single-use helpers; abstract only on the third repetition (rule of three) |
 | BH-04 | Duplicated code blocks instead of reuse | CH-08 | Reuse existing utilities; extract a shared helper at 3 occurrences (DRY) |
 | BH-05 | Tests omitted unless explicitly requested | CH-21 | Tests mandatory (happy path + edge/error cases); enforce a coverage gate |
+| BH-10 | Wholesale file rewrites / reformatting untouched regions when a scoped edit suffices | CH-28 | Make the smallest change that satisfies the task; never reformat or restructure unrelated lines in the same edit (CH-28). Required guards/cleanups (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors still apply. |
 
 ### AI-specific correctness
 

--- a/examples/software-project/expected/references/code-hygiene-rules.reference.md
+++ b/examples/software-project/expected/references/code-hygiene-rules.reference.md
@@ -191,6 +191,105 @@ detail. Where the cross-link is `—`, the catalog entry is itself the rule.
 This rule does not duplicate `@security`'s domain (single-source-of-truth,
 [[CH-05]] / [[CH-14]]).
 
+### CH-26 — Agent Tool Declarations Must Follow the Principle of Least Authority
+
+**Category:** Agent Governance
+**Severity:** High
+
+Each agent's `tools:` YAML field must list only those tools minimally required
+to perform the agent's declared function. Excessive grants are a violation even
+if the agent never exercises the extra capability in practice.
+
+**Guidance by role archetype:**
+
+| Archetype | Typical tools | Notes |
+|---|---|---|
+| Auditors, validators, navigators, critics | `read`, `search` | Read-only by nature; no write or execute grants |
+| Log-writing agents (conflict log, delivery receipt) | `read`, `edit`, `search` | `edit` scoped to log file writes |
+| Execution agents (git, build, format conversion) | `read`, `execute`, `search` | `execute` only when body prose documents a specific shell-invocation step |
+| Writing/production agents | `read`, `edit`, `search` | Standard content-creation set |
+| Delegation agents (orchestrators, experts) | `read`, `edit`, `search`, `execute`, `agent` | Only when all are justified by declared procedures |
+
+**Prohibited patterns:**
+- `execute` on an agent whose Invariant Core and declared procedures contain no shell command invocation
+- `--allow-all-tools` on any subprocess invocation of a Copilot/AI CLI (use `--available-tools=<list>` instead)
+- Tool grants copied from a similar agent without re-evaluating the target agent's actual needs
+- Granting `agent` to an agent that has no `handoffs:` entries and no sub-agent delegation procedures
+
+**Enforcement check:**
+```
+# For each .agent.md file: read its tools: list and its Invariant Core / procedures.
+# Flag any tool that has no corresponding step or body reference justifying its use.
+# Verify no subprocess call uses --allow-all-tools.
+grep -rn "\-\-allow-all-tools" src/
+```
+
+### CH-27 — Prefer Long-Lived Utilities Over Ad-Hoc Scripts
+
+**Category:** Modularity / Reuse
+**Severity:** Medium
+
+*Applies to code artifacts.* If a feature being created or managed is **likely to
+be used again**, the logic that creates or manipulates it must live in a
+long-lived, reusable utility (module, library function, CLI subcommand) — not in
+an ad-hoc script, **and not in a script merely *tagged* `RECURRING`/`UTILITY` yet
+re-authored each time.**
+
+**Distinct violation (not redundant with [[CH-02]]/[[CH-03]]):** CH-02 requires
+*tagging and deleting* one-off scripts and CH-03 keeps ad-hoc scripts out of
+source — both are satisfied by an agent that nonetheless keeps writing fresh
+throwaway scripts for recurring work. CH-27 adds the affirmative duty those rules
+do not state: recurring operational work must be **promoted to a durable utility**,
+not repeatedly re-scripted.
+
+**Boundary vs. [[CH-08]] (rule of three) and BH-03:** CH-27 does **not** lower
+CH-08's 3-occurrence extraction threshold and does **not** mandate premature
+abstraction of genuinely single-use helpers (BH-03 in the bad-habits catalog). The
+trigger is foreseeable recurrence judged from the task, not raw repetition count.
+
+**Report-only.** Like every `@code-hygiene` finding, CH-27 is reported; it triggers
+no `@cleanup` deletion of its own.
+
+**Enforcement check (illustrative):**
+```
+# Flag repeated/dated one-off scripts doing equivalent work (fix_*, run_*_v2,
+# dated throwaways), or scripts tagged RECURRING/UTILITY that duplicate logic
+# better housed in a module. Recommend promotion to a long-lived utility.
+```
+
+### CH-28 — Prefer Minimal, Scoped Edits
+
+**Category:** Change Discipline
+**Severity:** Medium (advisory)
+
+*Applies to code artifacts.*
+
+> **Constraints first (closes the "minimal-diff" loophole):** CH-28 NEVER excuses
+> skipping a *required* change. Dead-code removal ([[CH-10]]), correctness guards
+> ([[CH-23]]/[[CH-24]]), and type checks ([[CH-22]]) are mandatory **even when they
+> add lines.** CH-28 does NOT block *sanctioned, scoped* refactors ([[CH-07]]
+> structure carves, [[CH-08]] extractions) or `@agent-refactor`'s mandate — those
+> are intentional work. CH-28 targets only **incidental** scope creep within an
+> otherwise-unrelated change.
+
+Subject to the constraints above: a change should touch only the lines its task
+requires. When an outcome is achievable in a small, localized diff, do not rewrite
+surrounding code, reformat untouched regions, or expand scope. Gratuitous churn
+obscures intent, inflates review cost, and is a common AI-agent failure mode (see
+BH-10 in the bad-habits catalog).
+
+**Advisory & precedented.** CH-28 is reported, never blocking, and triggers no
+deletion. It is not mechanically counted — its enforcement check is illustrative
+**exactly as [[CH-24]] and [[CH-25]] already are.**
+
+**Enforcement check (illustrative):**
+```
+# Judgment-based: report a diff whose churn (rewrites, reformatting of untouched
+# regions, scope expansion) appears disproportionate to the stated task. Never
+# flag a required change (CH-10/CH-22/CH-23/CH-24) or a sanctioned CH-07/CH-08
+# refactor. No automated metric.
+```
+
 <!-- Example:
 ### CH-21 — Project-Specific Rule Name
 

--- a/examples/software-project/expected/references/unix-philosophy-mapping.reference.md
+++ b/examples/software-project/expected/references/unix-philosophy-mapping.reference.md
@@ -2,7 +2,7 @@
 # Unix Philosophy — Code Hygiene Mapping (WebAppBackend)
 
 > **Purpose:** Document how code-hygiene rules align with principles from Unix system design and software architecture
-> **Applies to:** CH-01 through CH-24 rule interpretations
+> **Applies to:** CH-01 through CH-28 rule interpretations
 > **Relationship:** This is a *reference for reasoning*, not the authoritative source of rules. See `code-hygiene-rules.reference.md` for the complete enforcement catalog.
 > **Authority Position:** Complements (not supersedes) the authority hierarchy defined in orchestrator.agent.md
 > **Maintenance:** Updated by `@agent-updater` when code-hygiene-rules.reference.md changes AND when interpretations of Unix principles need clarification
@@ -111,7 +111,10 @@ This principle insists on **discoverability and explicitness**. Hidden behaviors
 
 ## Extension Rules (CH-21+) and Design Principles
 
-The repository adds four enforcement rules. These are **project-specific operational requirements**, not derived from Unix philosophy, but complementary to it:
+The repository adds eight enforcement rules (CH-21 through CH-28). CH-21–CH-26 are
+largely **project-specific operational requirements** complementary to Unix
+philosophy; CH-27 and CH-28 align *directly* with it (Software Tools and the Rule
+of Simplicity, respectively):
 
 | Rule | Tier | Principle Connection |
 |------|------|---------------------|
@@ -119,6 +122,10 @@ The repository adds four enforcement rules. These are **project-specific operati
 | **CH-22** — Type Check Function/Class Inputs | 3 | **Type Safety.** Type checking makes input contracts explicit. Implicit type coercion hides expectations and causes subtle bugs. (Project-specific mandate; complements simplicity principles.) |
 | **CH-23** — Fail Fast on Invalid Inputs | 3 | **Defensive Programming.** Explicit errors reveal problems early. Silent failures hide bugs deep in a system, making them expensive to diagnose. (Project-specific mandate; aligns with transparency but not Unix-specific.) |
 | **CH-24** — Exception Handling Is a Last Resort; Encode Conditions Explicitly | 3 | **Transparency + Defensive Programming.** Encoding cases in dictionaries and failing hard keeps the program's true state visible; broad `try`/`except` hides brokenness and defeats fast iterative debugging. Aligns with "Value Transparency and Clarity" — behavior must be discoverable, not buried under blanket error suppression. (Project-specific mandate; reinforces [[CH-23]].) |
+| **CH-25** — Screen AI-Generated Code Against the Bad-Habits Catalog | 3 | **Process / Quality.** AI-authored code carries recurring quality/correctness habits; screening catches them before integration. (Project-specific mandate; security-class habits are `@security`'s domain.) |
+| **CH-26** — Agent Tool Declarations Follow Least Authority (PoLA) | 2 | **Make Programs That Work Together.** Minimal authority mirrors minimal, well-scoped interfaces — an agent granted only what it needs is easier to reason about and compose. (Governance mandate.) |
+| **CH-27** — Prefer Long-Lived Utilities Over Ad-Hoc Scripts | 1 | **Software Tools / "Make each program do one thing well."** Recurring work belongs in durable, reusable tools, not throwaway scripts. Directly expresses the Unix "build reusable tools" ethos. |
+| **CH-28** — Prefer Minimal, Scoped Edits | 1 | **Rule of Simplicity / Rule of Economy ("Design for Simplicity").** The smallest change that satisfies the task keeps intent and program state legible; gratuitous churn is the complexity Unix philosophy warns against. (Advisory; never overrides required changes or sanctioned refactors.) |
 
 ---
 
@@ -131,7 +138,7 @@ Understanding the alignment between rules and design principles helps developers
 3. **Extend the rule set** — New rules should be grounded in principles or clearly justified as project-specific
 4. **Maintain over time** — Knowing *why* a rule exists makes it easier to keep it in sync as the project evolves
 
-**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-24) that serve operational needs independent of Unix philosophy.
+**Caveat:** This mapping documents which rules *happen to align with* Unix principles. It does not claim that Unix philosophy is the only valid source of design wisdom, or that all project rules must derive from it. The code-hygiene agent also enforces project-specific rules (CH-21–CH-26) that serve operational needs independent of Unix philosophy, plus CH-27–CH-28 which align with it directly.
 
 ---
 

--- a/references/ai-bad-habits-watch.md
+++ b/references/ai-bad-habits-watch.md
@@ -29,6 +29,7 @@ deliberately not catalogued here.
 | BH-03 | Single-use helper functions adding needless indirection | — | Inline single-use helpers; abstract only on the third repetition (rule of three) |
 | BH-04 | Duplicated code blocks instead of reuse | CH-08 | Reuse existing utilities; extract a shared helper at 3 occurrences (DRY) |
 | BH-05 | Tests omitted unless explicitly requested | CH-21 | Tests mandatory (happy path + edge/error cases); enforce a coverage gate |
+| BH-10 | Wholesale file rewrites / reformatting untouched regions when a scoped edit suffices | CH-28 | Make the smallest change that satisfies the task; never reformat or restructure unrelated lines in the same edit (CH-28). Required guards/cleanups (CH-10/CH-22/CH-23/CH-24) and sanctioned refactors still apply. |
 
 ### AI-specific correctness
 

--- a/tests/test_ai_bad_habits.py
+++ b/tests/test_ai_bad_habits.py
@@ -130,7 +130,7 @@ def test_apply_rejects_unknown_operation(monkeypatch, tmp_path: Path) -> None:
 
 # --- catalog integrity (allocation invariants) ------------------------------
 
-_VALID_CH = {f"CH-{n:02d}" for n in range(1, 26)}
+_VALID_CH = {f"CH-{n:02d}" for n in range(1, 29)}
 _ALLOWED_CATEGORIES = {"hygiene", "correctness", "process"}
 
 
@@ -157,6 +157,7 @@ def test_known_corrective_mappings() -> None:
     assert by_id["BH-04"]["cross_links"] == ("CH-08",)   # dup code
     assert by_id["BH-05"]["cross_links"] == ("CH-21",)   # tests omitted
     assert by_id["BH-07"]["cross_links"] == ("CH-23",)   # output shape-validation
+    assert by_id["BH-10"]["cross_links"] == ("CH-28",)   # wholesale-rewrite -> minimal edits
     # The two correctness entries keep only the quality angle and point security
     # readers at @security.
     assert "@security" in by_id["BH-06"]["fix"]           # hallucinated deps
@@ -165,9 +166,9 @@ def test_known_corrective_mappings() -> None:
 
 def test_bh_ids_unique_and_contiguous() -> None:
     ids = [e["id"] for e in ai_bad_habits.LOCAL_CATALOG]
-    assert len(ids) == len(set(ids)) == 9
+    assert len(ids) == len(set(ids)) == 10
     nums = sorted(int(i.split("-")[1]) for i in ids)
-    assert nums == list(range(1, 10))
+    assert nums == list(range(1, 11))
 
 
 def test_catalog_placeholder_resolves_with_no_unresolved_token() -> None:
@@ -175,7 +176,7 @@ def test_catalog_placeholder_resolves_with_no_unresolved_token() -> None:
     assert set(ph) == {"AI_BAD_HABITS_CATALOG"}
     body = ph["AI_BAD_HABITS_CATALOG"]
     assert "{AI_BAD_HABITS_CATALOG}" not in body
-    assert "BH-01" in body and "BH-09" in body
+    assert "BH-01" in body and "BH-09" in body and "BH-10" in body
     assert "Corrective pattern" in body
     assert "Tracked upstream sources" not in body
 

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -206,6 +206,36 @@ _REFACTOR_MODULES = (
 )
 
 
+_UNIVERSAL_CH = REPO_ROOT / "agentteams/templates/universal/code-hygiene.template.md"
+_DOMAIN_CH = REPO_ROOT / "agentteams/templates/domain/code-hygiene-rules-reference.template.md"
+
+
+def test_extension_rules_present_in_both_templates() -> None:
+    """Parity guard: CH-26/CH-27/CH-28 must appear in BOTH the universal agent
+    template and the domain enforcement reference, so the agent summary and the
+    enforcement catalog never drift apart (the same CH-20 hazard the rules guard)."""
+    universal = _UNIVERSAL_CH.read_text(encoding="utf-8")
+    domain = _DOMAIN_CH.read_text(encoding="utf-8")
+    for rule in ("CH-26", "CH-27", "CH-28"):
+        assert rule in universal, f"{rule} missing from {_UNIVERSAL_CH.name}"
+        assert rule in domain, f"{rule} missing from {_DOMAIN_CH.name}"
+
+
+def test_ch28_constraints_sentence_present() -> None:
+    """CH-28 is only safe (no CH-20 contradiction with CH-10/CH-22/CH-23/CH-24 or
+    the refactor agents) because it front-loads the constraint that required
+    changes and sanctioned refactors override it. Guard that sentence so a future
+    trim cannot silently reintroduce the contradiction."""
+    universal = _UNIVERSAL_CH.read_text(encoding="utf-8")
+    domain = _DOMAIN_CH.read_text(encoding="utf-8")
+    # The "required changes still apply even when they add lines" constraint must
+    # be stated verbatim somewhere; the universal template carries it un-wrapped.
+    assert "even when they add lines" in " ".join(universal.split())
+    # Both templates must cite the rules CH-28 defers to, so the exemption is explicit.
+    for ref in ("CH-10", "CH-22", "CH-23", "CH-24", "CH-07", "CH-08"):
+        assert ref in domain, f"CH-28 constraint must reference {ref} in {_DOMAIN_CH.name}"
+
+
 def test_refactor_modules_are_fully_type_annotated() -> None:
     """CH-22: every module-level function in the refactor's cli/* + registry + errors
     modules must annotate its parameters (except self/cls) and its return type.


### PR DESCRIPTION
Add two behavioral rules to the agent architecture generated by agentteams,
hosted in the code-hygiene agent generation pipeline:

- CH-27 Prefer Long-Lived Utilities Over Ad-Hoc Scripts (Modularity, Medium)
- CH-28 Prefer Minimal, Scoped Edits (Change Discipline, Medium/advisory),
  reinforced by a new BH-10 bad-habits catalog entry cross-linked to CH-28

Also promote the previously untracked, repo-local PoLA rule into the templates
as CH-26 so extension numbering is coherent across all generated teams, and fix
the stale unix-philosophy mapping header (CH-24 -> CH-28) with backfilled rows.

Plan was passed through adversarial + conflict audits; findings incorporated
(CH-26 ID-collision resolved via promotion; CH-27 distinct-violation framing vs
CH-02; CH-28 advisory precedent on CH-24/CH-25; constraints front-loaded; rules
scoped to code artifacts). Cross-links keep all boundaries single-sourced (CH-20).

Templates, all four example goldens, and the root bad-habits artifact regenerated.
Tests: bad-habits catalog count 9->10 and _VALID_CH extended to CH-28; new parity
guard pins CH-26/27/28 in both templates and the CH-28 constraint sentence.
Full suite: 1388 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

(cherry picked from commit eb274554e8cf13c6e4c3b7eb403989e128421d80;
re-applied cleanly onto main @ 06db126 — full suite 1681 passed, 1 skipped.
Goldens auto-merged + verified against current templates via snapshot tests.)
