### PR TITLE
feat(goose): Phase-4a goose-native — opt-in recipe `parameters`

### DIFF
--- a/agentteams/analyze.py
+++ b/agentteams/analyze.py
@@ -417,7 +417,69 @@ def build_manifest(description: dict[str, Any], *, framework: str = "copilot-vsc
     declared_servers = description.get("mcp_servers")
     if isinstance(declared_servers, list) and declared_servers:
         manifest["mcp_servers"] = list(declared_servers)
+    # Phase-4a goose-native (opt-in): copy operator-DECLARED Goose recipe parameters
+    # through to the manifest. Added only when non-empty, so manifests for briefs
+    # that declare none are byte-identical (mirrors the mcp_servers pattern above).
+    recipe_parameters = _normalize_recipe_parameters(description.get("recipe_parameters"))
+    if recipe_parameters:
+        manifest["recipe_parameters"] = recipe_parameters
     return manifest
+
+
+_RECIPE_PARAM_INPUT_TYPES = frozenset(
+    {"string", "number", "boolean", "date", "file", "select"}
+)
+
+
+def _normalize_recipe_parameters(raw: Any) -> list[dict[str, str]]:
+    """Normalize a brief's ``recipe_parameters`` into validated Goose recipe params.
+
+    Phase-4a goose-native (opt-in). Drops malformed entries (missing/blank string
+    ``key``); defaults ``input_type=string`` and ``requirement=optional``. Enforces
+    two Goose hard rules: optional non-file params MUST carry a ``default`` ("" when
+    unset), and ``file`` params cannot have a default (so they are coerced to
+    ``required``). Returns ``[]`` when ``raw`` is absent or not a list, so manifests
+    for briefs that declare none are unchanged.
+    """
+    if not isinstance(raw, list):
+        return []
+    params: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        key = item.get("key")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        input_type = item.get("input_type")
+        if input_type not in _RECIPE_PARAM_INPUT_TYPES:
+            input_type = "string"
+        requirement = item.get("requirement")
+        if requirement not in ("required", "optional"):
+            requirement = "optional"
+        param: dict[str, str] = {
+            "key": key.strip(),
+            "input_type": input_type,
+            "requirement": requirement,
+        }
+        description = item.get("description")
+        if isinstance(description, str) and description.strip():
+            param["description"] = description.strip()
+        default = item.get("default")
+        if input_type == "file":
+            # Goose forbids defaults on file params; optional+file is contradictory.
+            param["requirement"] = "required"
+        elif default is not None:
+            if isinstance(default, bool):
+                param["default"] = "true" if default else "false"
+            elif isinstance(default, str):
+                param["default"] = default
+            else:
+                param["default"] = str(default)
+        elif requirement == "optional":
+            # Goose requires optional params to declare a default.
+            param["default"] = ""
+        params.append(param)
+    return params
 
 
 # ---------------------------------------------------------------------------

--- a/agentteams/frameworks/goose.py
+++ b/agentteams/frameworks/goose.py
@@ -56,6 +56,9 @@ _RECIPE_MODEL_KEY_RE = re.compile(r"^\s*model:", re.MULTILINE)
 _RECIPE_TITLE_RE = re.compile(r'^title:\s*".+?"', re.MULTILINE)
 _RECIPE_INSTRUCTIONS_RE = re.compile(r"^instructions:\s*\|", re.MULTILINE)
 _RECIPE_SUB_PATH_RE = re.compile(r'path:\s*"([^"]+)"')
+# Phase-4a: a `parameters:` block (when present) must list `- key:` entries.
+_RECIPE_PARAMETERS_RE = re.compile(r"^parameters:\s*$", re.MULTILINE)
+_RECIPE_PARAM_KEY_RE = re.compile(r'^\s+-\s+key:\s*"', re.MULTILINE)
 
 # Forbidden-shape guards for emitted recipes (goose-integration.plan §6.5 gotchas).
 # These have no other validator backing, so a typo would otherwise pass silently.
@@ -158,6 +161,8 @@ def _validate_recipe_yaml(yaml_text: str, recipes_dir: Path | None = None) -> li
         violations.append("forbidden type: sse (use streamable_http; sse is deprecated)")
     if _RECIPE_FORBIDDEN_CONTEXT_RE.search(yaml_text):
         violations.append("forbidden context: field (not a recipe field)")
+    if _RECIPE_PARAMETERS_RE.search(yaml_text) and not _RECIPE_PARAM_KEY_RE.search(yaml_text):
+        violations.append("parameters: block present but lists no '- key:' entries")
     if recipes_dir is not None:
         for path_val in _RECIPE_SUB_PATH_RE.findall(yaml_text):
             resolved = (recipes_dir / path_val).resolve()
@@ -219,6 +224,16 @@ class GooseAdapter(FrameworkAdapter):
                 })
             if sub_recipes:
                 extensions.append("summon")
+            # Phase-4a (opt-in): emit declared recipe parameters on the orchestrator
+            # (the team entry point) and reference each key in a controlled prompt
+            # suffix so the Goose params<->{{ template }} coupling stays valid.
+            recipe_parameters = manifest.get("recipe_parameters") or None
+            prompt = _ORCHESTRATOR_PROBE_PROMPT
+            if recipe_parameters:
+                refs = "; ".join(
+                    f"{p['key']}={{{{ {p['key']} }}}}" for p in recipe_parameters
+                )
+                prompt = f"{prompt}\n\nRuntime inputs: {refs}"
             return _emit_recipe(
                 title=name,
                 description=description,
@@ -226,7 +241,8 @@ class GooseAdapter(FrameworkAdapter):
                 extensions=extensions,
                 sub_recipes=sub_recipes or None,
                 # W6: probe prompt enables non-interactive `goose run --recipe` in CI.
-                prompt=_ORCHESTRATOR_PROBE_PROMPT,
+                prompt=prompt,
+                parameters=recipe_parameters,
                 mcp_extensions=mcp_exts,
                 mcp_notes=mcp_notes,
             )
@@ -618,6 +634,7 @@ def _emit_recipe(
     extensions: list[str],
     sub_recipes: list[dict[str, str]] | None = None,
     prompt: str | None = None,
+    parameters: list[dict[str, str]] | None = None,
     mcp_extensions: list[dict[str, Any]] | None = None,
     mcp_notes: list[str] | None = None,
 ) -> str:
@@ -626,6 +643,13 @@ def _emit_recipe(
     W6: The optional `prompt` field, when provided, is emitted after `description`
     and enables non-interactive `goose run --recipe` execution in CI pipelines
     (the --recipe and --text flags are mutually exclusive in Goose CLI).
+
+    Phase-4a: ``parameters`` (opt-in), when non-empty, is emitted as a `parameters:`
+    block (Goose recipe runtime inputs). Each entry is a normalized dict with `key`,
+    `input_type`, `requirement`, optional `default`, optional `description` — every
+    scalar double-quoted so special chars cannot break the hand-built YAML. Callers
+    that reference the keys via ``{{ key }}`` (e.g. the orchestrator prompt) keep the
+    Goose params↔template coupling valid. Defaults to None → byte-identical baseline.
 
     ``mcp_extensions`` (opt-in) are operator-specified MCP servers rendered as
     ``stdio``/``streamable_http`` extensions after the builtin/platform ones; every
@@ -648,6 +672,16 @@ def _emit_recipe(
     for note in mcp_notes or []:
         # Column-0 comment terminates the instructions block scalar; Goose ignores it.
         lines.append(f"# agentteams MCP: {note}")
+    if parameters:
+        lines.append("parameters:")
+        for p in parameters:
+            lines.append(f"  - key: {_yaml_dq(p['key'])}")
+            lines.append(f"    input_type: {_yaml_dq(p.get('input_type', 'string'))}")
+            lines.append(f"    requirement: {_yaml_dq(p.get('requirement', 'optional'))}")
+            if "default" in p:
+                lines.append(f"    default: {_yaml_dq(p['default'])}")
+            if p.get("description"):
+                lines.append(f"    description: {_yaml_dq(p['description'])}")
     lines.append("extensions:")
     for ext in extensions:
         if ext == "developer":

--- a/schemas/project-description.schema.json
+++ b/schemas/project-description.schema.json
@@ -356,6 +356,22 @@
       "type": "array",
       "description": "Optional operator-SPECIFIED MCP server definitions to emit for this team (each conforms to mcp-server.schema.json). This is the input for automating *specified* servers (vs. mcp_hints, which only feeds the BUILD/USE/DEFER detection rubric). Purely declarative: entries are copied to the team-manifest's mcp_servers[] and emitted as the INERT .claude/mcp-servers.agentteams.json only when an MCP host-feature token is enabled (claude:mcp or bridge:copilot-vscode-to-claude:mcp). Provisions nothing on its own; credentialed activation remains a separate operator step. See references/mcp-auto-detection-report.md §5.4/§6.",
       "items": { "$ref": "mcp-server.schema.json" }
+    },
+    "recipe_parameters": {
+      "type": "array",
+      "description": "Optional Goose recipe parameters (Phase-4a goose-native). Declares typed runtime inputs for the generated Goose team: copied to the team-manifest and, for --framework goose, emitted as a `parameters:` block on the ORCHESTRATOR recipe (referenced via {{ key }}) so it accepts `goose run --recipe orchestrator.yaml --params key=value`. Goose-only; ignored by other frameworks. Opt-in: absent/empty → recipes byte-identical.",
+      "items": {
+        "type": "object",
+        "required": ["key"],
+        "additionalProperties": false,
+        "properties": {
+          "key": { "type": "string", "description": "Parameter name; referenced as {{ key }}." },
+          "input_type": { "type": "string", "enum": ["string", "number", "boolean", "date", "file", "select"], "description": "Goose parameter input_type (default: string)." },
+          "requirement": { "type": "string", "enum": ["required", "optional"], "description": "Goose requirement (default: optional). Optional non-file params receive a default; file params are coerced to required (goose forbids file defaults)." },
+          "default": { "type": ["string", "number", "boolean"], "description": "Default for optional non-file params (file params cannot have a default)." },
+          "description": { "type": "string" }
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/schemas/team-manifest.schema.json
+++ b/schemas/team-manifest.schema.json
@@ -341,6 +341,22 @@
       "type": "array",
       "description": "MCP server definitions (each conforms to mcp-server.schema.json) accepted for emission. Populated only when MCP host-features are enabled.",
       "items": { "$ref": "mcp-server.schema.json" }
+    },
+    "recipe_parameters": {
+      "type": "array",
+      "description": "Optional Goose recipe parameters (Phase-4a goose-native). When non-empty, emitted as a `parameters:` block on the generated Goose ORCHESTRATOR recipe and referenced via `{{ key }}` so the recipe accepts `goose run --recipe orchestrator.yaml --params key=value`. Goose-only; ignored by other frameworks. Opt-in: absent/empty → recipes byte-identical to baseline.",
+      "items": {
+        "type": "object",
+        "required": ["key"],
+        "additionalProperties": false,
+        "properties": {
+          "key": { "type": "string", "description": "Parameter name; referenced as {{ key }}." },
+          "input_type": { "type": "string", "enum": ["string", "number", "boolean", "date", "file", "select"], "description": "Goose parameter input_type (default: string)." },
+          "requirement": { "type": "string", "enum": ["required", "optional"], "description": "Goose requirement (default: optional). Optional non-file params receive a default; file params are coerced to required (goose forbids file defaults)." },
+          "default": { "type": ["string", "number", "boolean"], "description": "Default for optional non-file params (file params cannot have a default)." },
+          "description": { "type": "string" }
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/tests/test_goose_recipe_parameters.py
+++ b/tests/test_goose_recipe_parameters.py
@@ -1,0 +1,248 @@
+"""Phase-4a goose-native: opt-in Goose recipe `parameters`.
+
+Covers the normalization (analyze._normalize_recipe_parameters), the opt-in
+manifest passthrough (analyze.build_manifest), the YAML emission + validation
+(frameworks.goose._emit_recipe / _validate_recipe_yaml), orchestrator-only
+emission with the params<->{{ template }} coupling, the validator shape check,
+and byte-identical additivity when no parameters are declared.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import jsonschema
+
+from agentteams.analyze import _normalize_recipe_parameters, build_manifest
+from agentteams.frameworks.goose import (
+    GooseAdapter,
+    _emit_recipe,
+    _validate_recipe_yaml,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_SCHEMA_PATH = REPO_ROOT / "schemas" / "team-manifest.schema.json"
+
+_ORCH_MD = """\
+---
+name: Orchestrator
+description: Routes work
+---
+
+# Orchestrator
+
+Routes all work.
+"""
+
+
+class TestNormalizeRecipeParameters:
+    def test_absent_or_non_list_returns_empty(self):
+        assert _normalize_recipe_parameters(None) == []
+        assert _normalize_recipe_parameters("nope") == []
+        assert _normalize_recipe_parameters({"key": "a"}) == []
+
+    def test_drops_malformed_entries(self):
+        raw = [
+            {"key": "ok"},
+            {"no_key": "x"},
+            "not-a-dict",
+            {"key": "   "},  # blank
+            {"key": 123},    # non-string
+        ]
+        assert [p["key"] for p in _normalize_recipe_parameters(raw)] == ["ok"]
+
+    def test_defaults_input_type_requirement_and_optional_default(self):
+        out = _normalize_recipe_parameters([{"key": "a"}])
+        assert out[0] == {
+            "key": "a",
+            "input_type": "string",
+            "requirement": "optional",
+            "default": "",  # goose: optional params must carry a default
+        }
+
+    def test_invalid_input_type_and_requirement_coerced(self):
+        out = _normalize_recipe_parameters(
+            [{"key": "a", "input_type": "bogus", "requirement": "weird"}]
+        )
+        assert out[0]["input_type"] == "string"
+        assert out[0]["requirement"] == "optional"
+
+    def test_required_param_has_no_default(self):
+        out = _normalize_recipe_parameters([{"key": "a", "requirement": "required"}])
+        assert "default" not in out[0]
+
+    def test_optional_default_preserved_and_stringified(self):
+        out = _normalize_recipe_parameters(
+            [
+                {"key": "s", "requirement": "optional", "default": "x"},
+                {"key": "n", "input_type": "number", "requirement": "optional", "default": 5},
+                {"key": "b", "input_type": "boolean", "requirement": "optional", "default": False},
+            ]
+        )
+        by = {p["key"]: p for p in out}
+        assert by["s"]["default"] == "x"
+        assert by["n"]["default"] == "5"
+        assert by["b"]["default"] == "false"  # bool lowercased for goose
+
+    def test_file_param_coerced_required_with_no_default(self):
+        out = _normalize_recipe_parameters(
+            [{"key": "f", "input_type": "file", "requirement": "optional", "default": "x"}]
+        )
+        assert out[0]["requirement"] == "required"
+        assert "default" not in out[0]
+
+    def test_description_trimmed_and_optional(self):
+        out = _normalize_recipe_parameters(
+            [{"key": "a", "description": "  hi  "}, {"key": "b", "description": "   "}]
+        )
+        assert out[0]["description"] == "hi"
+        assert "description" not in out[1]
+
+
+class TestBuildManifestPassthrough:
+    def test_added_when_declared(self):
+        m = build_manifest(
+            {"project_goal": "g", "recipe_parameters": [{"key": "a"}]}, framework="goose"
+        )
+        assert m["recipe_parameters"] == [
+            {"key": "a", "input_type": "string", "requirement": "optional", "default": ""}
+        ]
+
+    def test_no_key_when_absent(self):
+        m = build_manifest({"project_goal": "g"}, framework="goose")
+        assert "recipe_parameters" not in m  # additivity: byte-identical manifest
+
+    def test_no_key_when_all_malformed(self):
+        m = build_manifest(
+            {"project_goal": "g", "recipe_parameters": [{"no_key": 1}]}, framework="goose"
+        )
+        assert "recipe_parameters" not in m
+
+
+class TestEmitRecipeParameters:
+    def test_emit_block_validates(self):
+        params = [
+            {"key": "src", "input_type": "string", "requirement": "required", "description": "in"},
+            {"key": "env", "input_type": "select", "requirement": "optional", "default": ""},
+        ]
+        y = _emit_recipe(
+            title="T",
+            description="D",
+            instructions="body",
+            extensions=["developer"],
+            prompt="P {{ src }} {{ env }}",
+            parameters=params,
+        )
+        assert "parameters:" in y
+        assert '- key: "src"' in y
+        assert 'requirement: "required"' in y
+        assert _validate_recipe_yaml(y) == []
+
+    def test_no_block_when_none(self):
+        y = _emit_recipe(
+            title="T", description="D", instructions="body", extensions=["developer"]
+        )
+        assert "parameters:" not in y
+
+    def test_empty_list_emits_no_block(self):
+        y = _emit_recipe(
+            title="T",
+            description="D",
+            instructions="body",
+            extensions=["developer"],
+            parameters=[],
+        )
+        assert "parameters:" not in y
+
+    def test_forbidden_tokens_in_description_do_not_false_trip(self):
+        # A description containing envs:/context:/type: sse must not trip the
+        # column-0-anchored forbidden-key guards (it is a quoted single-line scalar).
+        params = [
+            {
+                "key": "k",
+                "input_type": "string",
+                "requirement": "optional",
+                "default": "",
+                "description": 'has envs: and context: and type: sse "quotes" too',
+            }
+        ]
+        y = _emit_recipe(
+            title="T",
+            description="D",
+            instructions="body",
+            extensions=["developer"],
+            prompt="P {{ k }}",
+            parameters=params,
+        )
+        assert _validate_recipe_yaml(y) == []
+
+
+class TestValidatorShapeCheck:
+    def test_parameters_block_without_keys_is_flagged(self):
+        bad = 'version: "1.0.0"\ntitle: "T"\ninstructions: |\n  body\nparameters:\nextensions:\n'
+        violations = _validate_recipe_yaml(bad)
+        assert any("parameters:" in v and "key:" in v for v in violations)
+
+
+class TestOrchestratorEmission:
+    @staticmethod
+    def _manifest(**extra):
+        base = {"project_name": "P", "output_files": [{"path": "alpha.agent.md"}]}
+        base.update(extra)
+        return base
+
+    def test_orchestrator_gets_params_and_coupled_prompt_refs(self):
+        adapter = GooseAdapter()
+        manifest = self._manifest(
+            recipe_parameters=[
+                {"key": "src", "input_type": "string", "requirement": "required"},
+                {"key": "env", "input_type": "select", "requirement": "optional", "default": ""},
+            ]
+        )
+        recipe = adapter.render_agent_file(_ORCH_MD, "orchestrator", manifest)
+        assert "parameters:" in recipe
+        assert '- key: "src"' in recipe
+        assert "Runtime inputs:" in recipe
+        # Coupling: every {{ x }} template var has a matching declared key.
+        template_vars = set(re.findall(r"\{\{\s*([a-zA-Z0-9_]+)\s*\}\}", recipe))
+        assert template_vars == {"src", "env"}
+        assert _validate_recipe_yaml(recipe) == []
+
+    def test_non_orchestrator_recipe_has_no_params(self):
+        adapter = GooseAdapter()
+        manifest = self._manifest(
+            recipe_parameters=[{"key": "src", "requirement": "required"}]
+        )
+        recipe = adapter.render_agent_file(_ORCH_MD, "alpha", manifest)
+        assert "parameters:" not in recipe
+
+    def test_orchestrator_without_params_is_unchanged(self):
+        adapter = GooseAdapter()
+        with_params = adapter.render_agent_file(
+            _ORCH_MD, "orchestrator", self._manifest()
+        )
+        assert "parameters:" not in with_params
+        assert "Runtime inputs:" not in with_params
+
+
+class TestSchemaContract:
+    def test_recipe_parameters_declared_and_validates(self):
+        schema = json.loads(MANIFEST_SCHEMA_PATH.read_text())
+        # Declared in the strict (additionalProperties:false) manifest schema, so the
+        # new manifest key is contract-valid rather than rejected.
+        assert "recipe_parameters" in schema["properties"]
+        manifest = build_manifest(
+            {
+                "project_goal": "g",
+                "recipe_parameters": [
+                    {"key": "src", "requirement": "required", "description": "d"},
+                    {"key": "env", "input_type": "select", "requirement": "optional", "default": "prod"},
+                ],
+            },
+            framework="goose",
+        )
+        jsonschema.Draft7Validator(
+            schema["properties"]["recipe_parameters"]
+        ).validate(manifest["recipe_parameters"])


### PR DESCRIPTION
First slice of the Phase-4 goose-native design
(references/phase4-goose-native-design.md). Lets a brief declare typed runtime
inputs for its Goose team via an opt-in `recipe_parameters` field; the generated
ORCHESTRATOR recipe emits them as a `parameters:` block and references each key in
a controlled prompt suffix ({{ key }}), so the recipe accepts
`goose run --recipe orchestrator.yaml --params key=value`.

- schemas: optional `recipe_parameters` array added to BOTH
  team-manifest.schema.json and project-description.schema.json (additive optional
  field => SemVer-minor; both are additionalProperties:false so the key must be
  declared or the manifest/brief is contract-invalid).
- analyze.py: `_normalize_recipe_parameters` — drops malformed entries; defaults
  input_type=string / requirement=optional; enforces goose hard rules (optional
  non-file params get a default; file params coerced to required with no default;
  bool defaults lowercased). Copied to the manifest only when non-empty, so
  manifests for briefs without params are byte-identical.
- goose.py: `_emit_recipe(parameters=...)` emits the block (every scalar via
  _yaml_dq); orchestrator branch wires it + the coupled prompt suffix;
  `_validate_recipe_yaml` gains a positive `parameters:` shape check (recipe_check
  inherits it). Bridge + non-orchestrator recipes untouched (keyword-only default).
- tests: tests/test_goose_recipe_parameters.py (20) — normalization,
  passthrough/additivity, emission+validation, forbidden-guard non-collision,
  orchestrator-only emission with params<->template coupling, validator shape
  check, schema contract.

Plan adversarially + conflict audited before implementation; revisions applied
(correct call-site = orchestrator at goose.py:222 not the bridge at :539; optional
default rule; dropped a runtime coupling regex in favor of emitter-guaranteed
coupling + unit test; both-schema additions mandatory). 4b (response) / 4c (retry)
/ 4d (per-agent extensions) remain deferred follow-ons. Full suite: 1701 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
