### PR TITLE
feat(goose): Phase-4c — recipe_retry self-validation loop

### DIFF
--- a/agentteams/analyze.py
+++ b/agentteams/analyze.py
@@ -21,6 +21,7 @@ from agentteams.mcp_detect import detect_mcp_candidates
 from agentteams.recipe_fields import (  # noqa: E402,F401 (carved CH-07; re-exported)
     _normalize_recipe_parameters,
     _normalize_recipe_response,
+    _normalize_recipe_retry,
 )
 from agentteams.manifest_format import (  # noqa: E402,F401 (carved CH-07; re-exported)
     _MANUAL_TOKEN_FULLMATCH_RE,
@@ -467,6 +468,12 @@ def build_manifest(description: dict[str, Any], *, framework: str = "copilot-vsc
     recipe_response = _normalize_recipe_response(description.get("recipe_response"))
     if recipe_response:
         manifest["recipe_response"] = recipe_response
+    # Phase-4c goose-native (opt-in): copy a declared Goose recipe retry config
+    # through to the manifest. Added only when it has ≥1 valid check, so manifests
+    # without one are byte-identical.
+    recipe_retry = _normalize_recipe_retry(description.get("recipe_retry"))
+    if recipe_retry:
+        manifest["recipe_retry"] = recipe_retry
     return manifest
 
 

--- a/agentteams/frameworks/goose.py
+++ b/agentteams/frameworks/goose.py
@@ -63,6 +63,10 @@ _RECIPE_PARAM_KEY_RE = re.compile(r'^\s+-\s+key:\s*"', re.MULTILINE)
 # Phase-4b: a `response:` block (when present) must carry a non-empty `json_schema:`.
 _RECIPE_RESPONSE_RE = re.compile(r"^response:\s*$", re.MULTILINE)
 _RECIPE_JSON_SCHEMA_RE = re.compile(r"^\s+json_schema:\s*\S", re.MULTILINE)
+# Phase-4c: a `retry:` block (when present) must carry `max_retries:` and ≥1 check `command:`.
+_RECIPE_RETRY_RE = re.compile(r"^retry:\s*$", re.MULTILINE)
+_RECIPE_MAX_RETRIES_RE = re.compile(r"^\s+max_retries:\s*\d", re.MULTILINE)
+_RECIPE_RETRY_CMD_RE = re.compile(r'^\s+command:\s*"', re.MULTILINE)
 
 # Forbidden-shape guards for emitted recipes (goose-integration.plan §6.5 gotchas).
 # These have no other validator backing, so a typo would otherwise pass silently.
@@ -169,6 +173,10 @@ def _validate_recipe_yaml(yaml_text: str, recipes_dir: Path | None = None) -> li
         violations.append("parameters: block present but lists no '- key:' entries")
     if _RECIPE_RESPONSE_RE.search(yaml_text) and not _RECIPE_JSON_SCHEMA_RE.search(yaml_text):
         violations.append("response: block present but has no non-empty json_schema: value")
+    if _RECIPE_RETRY_RE.search(yaml_text) and not (
+        _RECIPE_MAX_RETRIES_RE.search(yaml_text) and _RECIPE_RETRY_CMD_RE.search(yaml_text)
+    ):
+        violations.append("retry: block present but missing max_retries: or a check command:")
     if recipes_dir is not None:
         for path_val in _RECIPE_SUB_PATH_RE.findall(yaml_text):
             resolved = (recipes_dir / path_val).resolve()
@@ -243,6 +251,9 @@ class GooseAdapter(FrameworkAdapter):
             # Phase-4b (opt-in): emit a declared response json_schema so goose
             # validates the orchestrator's final output against it.
             recipe_response = manifest.get("recipe_response") or None
+            # Phase-4c (opt-in): emit a bounded retry block so goose re-runs the
+            # orchestrator until the declared shell checks pass.
+            recipe_retry = manifest.get("recipe_retry") or None
             return _emit_recipe(
                 title=name,
                 description=description,
@@ -253,6 +264,7 @@ class GooseAdapter(FrameworkAdapter):
                 prompt=prompt,
                 parameters=recipe_parameters,
                 response=recipe_response,
+                retry=recipe_retry,
                 mcp_extensions=mcp_exts,
                 mcp_notes=mcp_notes,
             )
@@ -646,6 +658,7 @@ def _emit_recipe(
     prompt: str | None = None,
     parameters: list[dict[str, str]] | None = None,
     response: dict[str, Any] | None = None,
+    retry: dict[str, Any] | None = None,
     mcp_extensions: list[dict[str, Any]] | None = None,
     mcp_notes: list[str] | None = None,
 ) -> str:
@@ -666,6 +679,10 @@ def _emit_recipe(
     `response:` block whose ``json_schema:`` value is single-line compact JSON (valid
     YAML, since YAML is a JSON superset) so goose validates the agent's final output.
     Defaults to None → byte-identical baseline.
+
+    Phase-4c: ``retry`` (opt-in), when truthy, is a normalized dict emitted as a
+    `retry:` block (bounded ``max_retries`` + ``timeout_seconds`` + shell ``checks``)
+    so goose re-runs until the checks pass. Defaults to None → byte-identical baseline.
 
     ``mcp_extensions`` (opt-in) are operator-specified MCP servers rendered as
     ``stdio``/``streamable_http`` extensions after the builtin/platform ones; every
@@ -706,6 +723,20 @@ def _emit_recipe(
         lines.append(
             f"  json_schema: {json.dumps(response, sort_keys=True, separators=(',', ':'))}"
         )
+    if retry:
+        # Hand-built (flat): ints unquoted, command/on_failure strings via _yaml_dq
+        # (which collapses newlines + escapes quotes → no YAML-structure breakout).
+        lines.append("retry:")
+        lines.append(f"  max_retries: {int(retry['max_retries'])}")
+        lines.append(f"  timeout_seconds: {int(retry['timeout_seconds'])}")
+        if "on_failure_timeout_seconds" in retry:
+            lines.append(f"  on_failure_timeout_seconds: {int(retry['on_failure_timeout_seconds'])}")
+        lines.append("  checks:")
+        for check in retry["checks"]:
+            lines.append(f"    - type: {_yaml_dq(check.get('type', 'shell'))}")
+            lines.append(f"      command: {_yaml_dq(check['command'])}")
+        if retry.get("on_failure"):
+            lines.append(f"  on_failure: {_yaml_dq(retry['on_failure'])}")
     lines.append("extensions:")
     for ext in extensions:
         if ext == "developer":

--- a/agentteams/recipe_fields.py
+++ b/agentteams/recipe_fields.py
@@ -1,16 +1,91 @@
 """Normalization for opt-in Goose recipe fields (Phase-4 goose-native).
 
 Pure, dependency-free normalizers for the operator-declared brief fields that map
-to Goose recipe blocks — ``recipe_parameters`` (4a) and ``recipe_response`` (4b).
-``analyze.build_manifest`` calls these and copies a result into the team-manifest
-only when truthy, so manifests for briefs that declare none are byte-identical.
-Kept out of ``analyze.py`` to hold that module under the CH-07 line ceiling;
-re-exported from ``analyze`` for backward compatibility.
+to Goose recipe blocks — ``recipe_parameters`` (4a), ``recipe_response`` (4b), and
+``recipe_retry`` (4c). ``analyze.build_manifest`` calls these and copies a result
+into the team-manifest only when truthy, so manifests for briefs that declare none
+are byte-identical. Kept out of ``analyze.py`` to hold that module under the CH-07
+line ceiling; re-exported from ``analyze`` for backward compatibility.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+
+def _normalize_recipe_response(raw: Any) -> dict[str, Any] | None:
+    """Normalize a brief's ``recipe_response`` into a Goose recipe response schema.
+
+    Phase-4b goose-native (opt-in). Goose stores ``response.json_schema`` as a raw
+    value with no load-time validity check, so the only guard against a silently
+    useless block is here. Returns ``None`` (→ no ``response:`` emitted) unless
+    ``raw`` is a non-empty dict carrying a non-empty string ``type``. Tolerates the
+    common double-wrap ``{"json_schema": {...}}`` by unwrapping when the top level
+    has no ``type``. Otherwise lenient — goose validates the schema's internals.
+    """
+    if not isinstance(raw, dict) or not raw:
+        return None
+    schema = raw
+    if "type" not in schema and isinstance(schema.get("json_schema"), dict):
+        schema = schema["json_schema"]  # tolerate {"json_schema": {...}} double-wrap
+    if not isinstance(schema.get("type"), str) or not schema["type"]:
+        return None
+    return schema
+
+
+_RETRY_MAX_CAP = 10
+_RETRY_DEFAULT_MAX = 3
+_RETRY_DEFAULT_TIMEOUT = 300
+_RETRY_TIMEOUT_CAP = 3600
+
+
+def _clamp_int(value: Any, default: int, lo: int, hi: int) -> int:
+    """Coerce ``value`` to int and clamp to [lo, hi]; ``default`` on non-numeric."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
+
+
+def _normalize_recipe_retry(raw: Any) -> dict[str, Any] | None:
+    """Normalize a brief's ``recipe_retry`` into a bounded Goose recipe retry block.
+
+    Phase-4c goose-native (opt-in). Goose's ``retry`` re-runs the recipe until the
+    shell ``checks`` pass. ``checks`` is a Goose-REQUIRED field, so a retry with no
+    valid check is an invalid recipe → returns ``None`` (no ``retry:`` emitted).
+    Safety (design §6, "never emit an unbounded retry"): ``max_retries`` is clamped to
+    [1, _RETRY_MAX_CAP] (default 3); a bounded ``timeout_seconds`` is ALWAYS emitted,
+    clamped to [1, _RETRY_TIMEOUT_CAP] (default 300). ``checks[].command`` /
+    ``on_failure`` are the operator's own shell commands (like a CI step), emitted
+    YAML-quoted; no sanitization beyond quoting (they are meant to be shell).
+    """
+    if not isinstance(raw, dict):
+        return None
+    checks: list[dict[str, str]] = []
+    for check in raw.get("checks") or []:
+        if not isinstance(check, dict):
+            continue
+        command = check.get("command")
+        if isinstance(command, str) and command.strip():
+            checks.append({"type": "shell", "command": command.strip()})
+    if not checks:
+        return None  # checks is goose-required; a check-less retry is invalid
+    retry: dict[str, Any] = {
+        "max_retries": _clamp_int(raw.get("max_retries"), _RETRY_DEFAULT_MAX, 1, _RETRY_MAX_CAP),
+        "timeout_seconds": _clamp_int(
+            raw.get("timeout_seconds"), _RETRY_DEFAULT_TIMEOUT, 1, _RETRY_TIMEOUT_CAP
+        ),
+        "checks": checks,
+    }
+    on_failure_timeout = _clamp_int(raw.get("on_failure_timeout_seconds"), 0, 0, _RETRY_TIMEOUT_CAP)
+    if on_failure_timeout > 0:
+        retry["on_failure_timeout_seconds"] = on_failure_timeout
+    on_failure = raw.get("on_failure")
+    if isinstance(on_failure, str) and on_failure.strip():
+        retry["on_failure"] = on_failure.strip()
+    return retry
+
 
 _RECIPE_PARAM_INPUT_TYPES = frozenset(
     {"string", "number", "boolean", "date", "file", "select"}
@@ -66,23 +141,3 @@ def _normalize_recipe_parameters(raw: Any) -> list[dict[str, str]]:
             param["default"] = ""
         params.append(param)
     return params
-
-
-def _normalize_recipe_response(raw: Any) -> dict[str, Any] | None:
-    """Normalize a brief's ``recipe_response`` into a Goose recipe response schema.
-
-    Phase-4b goose-native (opt-in). Goose stores ``response.json_schema`` as a raw
-    value with no load-time validity check, so the only guard against a silently
-    useless block is here. Returns ``None`` (→ no ``response:`` emitted) unless
-    ``raw`` is a non-empty dict carrying a non-empty string ``type``. Tolerates the
-    common double-wrap ``{"json_schema": {...}}`` by unwrapping when the top level
-    has no ``type``. Otherwise lenient — goose validates the schema's internals.
-    """
-    if not isinstance(raw, dict) or not raw:
-        return None
-    schema = raw
-    if "type" not in schema and isinstance(schema.get("json_schema"), dict):
-        schema = schema["json_schema"]  # tolerate {"json_schema": {...}} double-wrap
-    if not isinstance(schema.get("type"), str) or not schema["type"]:
-        return None
-    return schema

--- a/schemas/project-description.schema.json
+++ b/schemas/project-description.schema.json
@@ -377,6 +377,30 @@
       "type": "object",
       "additionalProperties": true,
       "description": "Optional Goose recipe response schema (Phase-4b goose-native). A JSON Schema ({type:object, properties, required, ...}) declaring the team's structured output; for --framework goose it is copied to the team-manifest and emitted as a `response:` block (json_schema) on the ORCHESTRATOR recipe so goose validates the final output against it. Goose-only; ignored by other frameworks. Opt-in: absent → recipes byte-identical."
+    },
+    "recipe_retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional Goose recipe retry config (Phase-4c goose-native). Declares self-validation for the generated Goose team: for --framework goose it is copied to the team-manifest and emitted as a `retry:` block on the ORCHESTRATOR recipe so goose re-runs until the shell `checks` pass. Safety: `max_retries` is clamped to 1-10 (default 3) and a bounded `timeout_seconds` (1-3600, default 300) is always emitted (never an unbounded retry). Requires ≥1 valid check or it is dropped. Goose-only; ignored by other frameworks. Opt-in: absent → recipes byte-identical.",
+      "properties": {
+        "max_retries": { "type": "integer", "description": "Max retry attempts (clamped to 1-10; default 3)." },
+        "timeout_seconds": { "type": "integer", "description": "Per-check command timeout in seconds (clamped to 1-3600; default 300)." },
+        "on_failure_timeout_seconds": { "type": "integer", "description": "Timeout for the on_failure command (optional)." },
+        "checks": {
+          "type": "array",
+          "description": "Shell checks defining success; ALL must pass.",
+          "items": {
+            "type": "object",
+            "required": ["command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "type": "string", "enum": ["shell"], "description": "Check type (only 'shell' supported)." },
+              "command": { "type": "string", "description": "Shell command; non-zero exit = check failed." }
+            }
+          }
+        },
+        "on_failure": { "type": "string", "description": "Shell command run when checks fail (optional)." }
+      }
     }
   },
   "additionalProperties": false

--- a/schemas/team-manifest.schema.json
+++ b/schemas/team-manifest.schema.json
@@ -362,6 +362,30 @@
       "type": "object",
       "additionalProperties": true,
       "description": "Optional Goose recipe response schema (Phase-4b goose-native). A JSON Schema ({type:object, properties, required, ...}); when present, emitted as a `response:` block (json_schema) on the generated Goose ORCHESTRATOR recipe so goose validates the team's final output against it. Goose-only; ignored by other frameworks. Opt-in: absent → recipes byte-identical."
+    },
+    "recipe_retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional Goose recipe retry config (Phase-4c goose-native). When present (and carrying ≥1 valid check), emitted as a `retry:` block on the generated Goose ORCHESTRATOR recipe: goose re-runs until the shell `checks` pass. Safety: `max_retries` is clamped to 1-10 (default 3) and a bounded `timeout_seconds` (1-3600, default 300) is always emitted. Goose-only; ignored by other frameworks. Opt-in: absent → recipes byte-identical.",
+      "properties": {
+        "max_retries": { "type": "integer", "description": "Max retry attempts (clamped to 1-10; default 3)." },
+        "timeout_seconds": { "type": "integer", "description": "Per-check command timeout in seconds (clamped to 1-3600; default 300)." },
+        "on_failure_timeout_seconds": { "type": "integer", "description": "Timeout for the on_failure command (optional)." },
+        "checks": {
+          "type": "array",
+          "description": "Shell checks defining success; ALL must pass.",
+          "items": {
+            "type": "object",
+            "required": ["command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "type": "string", "enum": ["shell"], "description": "Check type (only 'shell' supported)." },
+              "command": { "type": "string", "description": "Shell command; non-zero exit = check failed." }
+            }
+          }
+        },
+        "on_failure": { "type": "string", "description": "Shell command run when checks fail (optional)." }
+      }
     }
   },
   "additionalProperties": false

--- a/tests/test_goose_recipe_retry.py
+++ b/tests/test_goose_recipe_retry.py
@@ -1,0 +1,194 @@
+"""Phase-4c goose-native: opt-in Goose recipe `retry` (self-validation).
+
+Covers normalization (analyze._normalize_recipe_retry) incl. the safety clamps,
+opt-in manifest passthrough, hand-built YAML emission + validation, forbidden-guard
+non-collision for shell commands, orchestrator-only emission, the validator shape
+check, and byte-identical additivity when none is declared. (String assertions, not
+a YAML parser — the codebase intentionally has no YAML dependency.)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from agentteams.analyze import _normalize_recipe_retry, build_manifest
+from agentteams.frameworks.goose import (
+    GooseAdapter,
+    _emit_recipe,
+    _validate_recipe_yaml,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_SCHEMA_PATH = REPO_ROOT / "schemas" / "team-manifest.schema.json"
+
+_ORCH_MD = """\
+---
+name: Orchestrator
+description: Routes work
+---
+
+# Orchestrator
+
+Routes all work.
+"""
+
+_RETRY = {"max_retries": 3, "checks": [{"command": "pytest -q"}]}
+
+
+class TestNormalizeRecipeRetry:
+    def test_non_dict_returns_none(self):
+        assert _normalize_recipe_retry(None) is None
+        assert _normalize_recipe_retry("x") is None
+
+    def test_no_valid_checks_returns_none(self):
+        assert _normalize_recipe_retry({"max_retries": 3}) is None
+        assert _normalize_recipe_retry({"checks": []}) is None
+        assert _normalize_recipe_retry({"checks": [{"no": "cmd"}, {"command": "  "}]}) is None
+        assert _normalize_recipe_retry({"checks": ["not-a-dict"]}) is None
+
+    def test_valid_check_gets_shell_type(self):
+        out = _normalize_recipe_retry({"checks": [{"command": "make test"}]})
+        assert out["checks"] == [{"type": "shell", "command": "make test"}]
+
+    def test_max_retries_clamped_and_defaulted(self):
+        assert _normalize_recipe_retry({**_RETRY, "max_retries": 999})["max_retries"] == 10
+        assert _normalize_recipe_retry({**_RETRY, "max_retries": 0})["max_retries"] == 1
+        assert _normalize_recipe_retry({**_RETRY, "max_retries": -5})["max_retries"] == 1
+        assert _normalize_recipe_retry({**_RETRY, "max_retries": "lots"})["max_retries"] == 3
+        assert _normalize_recipe_retry({"checks": [{"command": "x"}]})["max_retries"] == 3
+
+    def test_timeout_always_present_and_bounded(self):
+        # absent -> default 300; never unbounded (design §6)
+        assert _normalize_recipe_retry(_RETRY)["timeout_seconds"] == 300
+        assert _normalize_recipe_retry({**_RETRY, "timeout_seconds": 99999})["timeout_seconds"] == 3600
+        assert _normalize_recipe_retry({**_RETRY, "timeout_seconds": 0})["timeout_seconds"] == 1
+        assert _normalize_recipe_retry({**_RETRY, "timeout_seconds": 45})["timeout_seconds"] == 45
+
+    def test_optional_on_failure_fields(self):
+        out = _normalize_recipe_retry(
+            {**_RETRY, "on_failure": "  cleanup.sh  ", "on_failure_timeout_seconds": 60}
+        )
+        assert out["on_failure"] == "cleanup.sh"
+        assert out["on_failure_timeout_seconds"] == 60
+        bare = _normalize_recipe_retry(_RETRY)
+        assert "on_failure" not in bare and "on_failure_timeout_seconds" not in bare
+
+
+class TestBuildManifestPassthrough:
+    def test_added_when_valid(self):
+        m = build_manifest({"project_goal": "g", "recipe_retry": _RETRY}, framework="goose")
+        assert m["recipe_retry"]["checks"] == [{"type": "shell", "command": "pytest -q"}]
+
+    def test_no_key_when_absent(self):
+        assert "recipe_retry" not in build_manifest({"project_goal": "g"}, framework="goose")
+
+    def test_no_key_when_no_checks(self):
+        m = build_manifest({"project_goal": "g", "recipe_retry": {"max_retries": 5}}, framework="goose")
+        assert "recipe_retry" not in m
+
+
+class TestEmitRecipeRetry:
+    def test_emits_valid_retry_block(self):
+        retry = {
+            "max_retries": 5,
+            "timeout_seconds": 30,
+            "on_failure_timeout_seconds": 60,
+            "checks": [{"type": "shell", "command": "pytest -q"}, {"type": "shell", "command": "ruff check ."}],
+            "on_failure": "git checkout .",
+        }
+        y = _emit_recipe(
+            title="T", description="D", instructions="body", extensions=["developer"], retry=retry
+        )
+        assert _validate_recipe_yaml(y) == []
+        assert "\nretry:\n" in y
+        assert "  max_retries: 5\n" in y  # unquoted int
+        assert "  timeout_seconds: 30\n" in y
+        assert "  on_failure_timeout_seconds: 60\n" in y
+        assert '      command: "pytest -q"' in y
+        assert '      command: "ruff check ."' in y
+        assert '    - type: "shell"' in y
+        assert '  on_failure: "git checkout ."' in y
+
+    def test_no_block_when_none(self):
+        y = _emit_recipe(title="T", description="D", instructions="body", extensions=["developer"])
+        assert "retry:" not in y
+
+    def test_empty_emits_no_block(self):
+        y = _emit_recipe(
+            title="T", description="D", instructions="body", extensions=["developer"], retry={}
+        )
+        assert "retry:" not in y
+
+    def test_command_with_forbidden_tokens_does_not_false_trip(self):
+        retry = {
+            "max_retries": 2,
+            "timeout_seconds": 10,
+            "checks": [{"type": "shell", "command": "grep envs: f && echo type: sse && echo context:"}],
+        }
+        y = _emit_recipe(
+            title="T", description="D", instructions="body", extensions=["developer"], retry=retry
+        )
+        assert _validate_recipe_yaml(y) == []
+        assert '      command: "grep envs: f && echo type: sse && echo context:"' in y
+
+    def test_command_with_quotes_and_newline_stays_one_scalar(self):
+        retry = {
+            "max_retries": 1,
+            "timeout_seconds": 5,
+            "checks": [{"type": "shell", "command": 'echo "hi"\nmodel: pwned'}],
+        }
+        y = _emit_recipe(
+            title="T", description="D", instructions="body", extensions=["developer"], retry=retry
+        )
+        assert _validate_recipe_yaml(y) == []  # no injected `model:` key
+        assert "\nmodel:" not in y  # newline collapsed -> no column-0 model: line
+        assert '\\"hi\\"' in y  # quotes escaped within the single scalar
+
+
+class TestValidatorShapeCheck:
+    def test_retry_without_max_retries_flagged(self):
+        bad = 'version: "1.0.0"\ntitle: "T"\ninstructions: |\n  b\nretry:\n  checks:\n    - type: "shell"\n      command: "x"\nextensions:\n'
+        assert any("retry:" in v for v in _validate_recipe_yaml(bad))
+
+    def test_retry_without_command_flagged(self):
+        bad = 'version: "1.0.0"\ntitle: "T"\ninstructions: |\n  b\nretry:\n  max_retries: 3\nextensions:\n'
+        assert any("retry:" in v for v in _validate_recipe_yaml(bad))
+
+
+class TestOrchestratorEmission:
+    @staticmethod
+    def _manifest(**extra):
+        base = {"project_name": "P", "output_files": [{"path": "alpha.agent.md"}]}
+        base.update(extra)
+        return base
+
+    def test_orchestrator_gets_retry(self):
+        adapter = GooseAdapter()
+        norm = _normalize_recipe_retry(_RETRY)
+        recipe = adapter.render_agent_file(_ORCH_MD, "orchestrator", self._manifest(recipe_retry=norm))
+        assert "\nretry:\n" in recipe
+        assert "  max_retries: 3\n" in recipe
+        assert "  timeout_seconds: 300\n" in recipe  # bounded default injected
+        assert _validate_recipe_yaml(recipe) == []
+
+    def test_non_orchestrator_has_no_retry(self):
+        adapter = GooseAdapter()
+        norm = _normalize_recipe_retry(_RETRY)
+        recipe = adapter.render_agent_file(_ORCH_MD, "alpha", self._manifest(recipe_retry=norm))
+        assert "retry:" not in recipe
+
+    def test_orchestrator_without_retry_unchanged(self):
+        adapter = GooseAdapter()
+        recipe = adapter.render_agent_file(_ORCH_MD, "orchestrator", self._manifest())
+        assert "retry:" not in recipe
+
+
+class TestSchemaContract:
+    def test_recipe_retry_declared_and_validates(self):
+        schema = json.loads(MANIFEST_SCHEMA_PATH.read_text())
+        assert "recipe_retry" in schema["properties"]
+        manifest = build_manifest({"project_goal": "g", "recipe_retry": _RETRY}, framework="goose")
+        jsonschema.Draft7Validator(schema["properties"]["recipe_retry"]).validate(manifest["recipe_retry"])


### PR DESCRIPTION
## Summary

Completes the Phase-4 goose-native trilogy by adding `recipe_retry` field support:
- New `_normalize_recipe_retry()` in `agentteams/recipe_fields.py` — enforces design §6 safety mandate: drops check-less retries (Goose requires `checks`), clamps `max_retries` to [1,10] (default 3), **always** emits a bounded `timeout_seconds` [1,3600] (default 300) so no retry is ever unbounded
- `_clamp_int()` helper in `recipe_fields.py`
- Retry emit logic in `frameworks/goose.py` (`_emit_recipe(retry=...)`, `_validate_recipe_yaml` shape check)
- JSON schema additions for `recipe_retry` in both schemas
- `tests/test_goose_recipe_retry.py` — 20-test suite covering clamp bounds, drop-when-no-checks, passthrough, emit+validate, forbidden-guard non-collision, orchestrator-only wiring, schema contract

## Rebase note

4b's `recipe_fields.py` (params + response) was on main before this branch. Conflict resolved: 4c's commit extends the existing file with the retry-specific content (`_normalize_recipe_retry`, `_clamp_int`, constants).

## Test plan
- [x] `tests/test_goose_recipe_retry.py` — 20 passed
- [x] `tests/test_goose_recipe_response.py` — 19 passed
- [x] `tests/test_goose_recipe_parameters.py` — 20 passed
- [x] `tests/test_code_hygiene.py` — all passed (analyze.py well under CH-07 ceiling)
- [ ] Full suite CI green

## Context
Phase-4a (recipe_parameters, PR #43) + Phase-4b (recipe_response, PR #48) on main. This PR completes Phase-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)